### PR TITLE
Remove the kibana spell steps as it was removed from CDK bundle

### DIFF
--- a/canonical-kubernetes/steps/step-02_cluster-info
+++ b/canonical-kubernetes/steps/step-02_cluster-info
@@ -17,9 +17,6 @@ NODES="$(~/kubectl $args get nodes | perl -p -e 's/\n/\\n/')"
 PODS="$(~/kubectl $args get --all-namespaces pods | perl -p -e 's/\n/\\n/')"
 SERVICES="$(~/kubectl $args get --all-namespaces services | perl -p -e 's/\n/\\n/')"
 
-juju expose kibana
-
-KIBANA_ADDR=$(unitAddress kibana 0)
-result="Nodes:\n$NODES\nPods:\n$PODS\nServices:\n$SERVICES\n\nView Kibana at http://$KIBANA_ADDR/"
+result="Nodes:\n$NODES\nPods:\n$PODS\nServices:\n$SERVICES"
 
 exposeResult "$result" 0 "true"


### PR DESCRIPTION
During the 1.5.1 release cycle it was determined we should strip the monitoring
stack from kubernetes, and offer them as a separate bundle permutation or
addon bundle with inheritance. This left a notice in conjure-up where kibana
was null.

This removes the kibana expose and http://null/ url for accessing kibana

Original request was documented over in https://github.com/juju-solutions/bundle-canonical-kubernetes/pull/138