### PR TITLE
Add more context to deployment error message

### DIFF
--- a/canonical-kubernetes/steps/00_deploy-done
+++ b/canonical-kubernetes/steps/00_deploy-done
@@ -1,12 +1,7 @@
 #!/usr/bin/env python3
 from conjureup.hooklib.writer import success, fail, error
 from conjureup.hooklib import juju
-import logging
 
-log = logging.getLogger('conjureup')
-
-
-log.debug("Running deploy-done for Kubernetes installation.")
 
 agent_states = juju.agent_states()
 agent_states_no_es = []
@@ -15,8 +10,11 @@ for row in agent_states:
     if 'elasticsearch' not in row[0]:
         agent_states_no_es.append(row)
 
-if any([state == 'error' for _, state, _ in agent_states]):
-    error('Error in one of the applications deployment')
+error_states = [(unit_name, current_state, workload_message)
+                for unit_name, current_state, workload_message in
+                agent_states if current_state == 'error']
+if len(error_states) > 0:
+    error('Deployment error in: {}'.format(error_states))
 
 if all([state == 'active' for _, state, _ in agent_states_no_es]):
     success('Applications are ready')


### PR DESCRIPTION
A little quick and dirty but should help surface much more information for deployment failures.
Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>