### PR TITLE
[kubernetes, openstack] Enable idmap isolated

### DIFF
--- a/canonical-kubernetes/steps/lxd-profile.yaml
+++ b/canonical-kubernetes/steps/lxd-profile.yaml
@@ -1,5 +1,6 @@
 name: juju-##MODEL##
 config:
+  security.idmap.isolated: "true"
   boot.autostart: "true"
   linux.kernel_modules: ip_tables,ip6_tables,netlink_diag,nf_nat,overlay
   raw.lxc: |

--- a/kubernetes-core/steps/lxd-profile.yaml
+++ b/kubernetes-core/steps/lxd-profile.yaml
@@ -1,5 +1,6 @@
 name: juju-##MODEL##
 config:
+  security.idmap.isolated: "true"
   boot.autostart: "true"
   linux.kernel_modules: ip_tables,ip6_tables,netlink_diag,nf_nat,overlay
   raw.lxc: |

--- a/openstack-novalxd/steps/lxd-profile.yaml
+++ b/openstack-novalxd/steps/lxd-profile.yaml
@@ -1,5 +1,6 @@
 name: juju-##MODEL##
 config:
+  security.idmap.isolated: "true"
   boot.autostart: "true"
   security.nesting: "true"
   security.privileged: "true"


### PR DESCRIPTION
This is to hopefully get around having a user update their /etc/sysctl.conf in
order to get a working deployment.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>