### PR TITLE
use juju-wait for making sure deployments are ready

### DIFF
--- a/canonical-kubernetes/steps/00_deploy-done
+++ b/canonical-kubernetes/steps/00_deploy-done
@@ -1,22 +1,6 @@
-#!/usr/bin/env python3
-from conjureup.hooklib.writer import success, fail, error
-from conjureup.hooklib import juju
+#!/bin/bash
 
+juju wait -m $JUJU_CONTROLLER:$JUJU_MODEL
 
-agent_states = juju.agent_states()
-agent_states_no_es = []
-
-for row in agent_states:
-    if 'elasticsearch' not in row[0]:
-        agent_states_no_es.append(row)
-
-error_states = [(unit_name, current_state, workload_message)
-                for unit_name, current_state, workload_message in
-                agent_states if current_state == 'error']
-if len(error_states) > 0:
-    error('Deployment error in: {}'.format(error_states))
-
-if all([state == 'active' for _, state, _ in agent_states_no_es]):
-    success('Applications are ready')
-
-fail('Applications not ready yet')
+printf '{"message": "Applications Ready", "returnCode": 0, "isComplete": "true"}'
+exit 0

--- a/ghost/steps/00_deploy-done
+++ b/ghost/steps/00_deploy-done
@@ -1,23 +1,6 @@
-#!/usr/bin/env python3
-from conjureup.hooklib.writer import success, fail, error, log
-from conjureup.hooklib import juju
+#!/bin/bash
 
-log.debug("Running deploy-done for Ghost installation.")
-juju_status = juju.status()
-agent_states = []
-for k, v in juju_status['applications'].items():
-    if 'units' in v:
-        for unit in v['units']:
-            _unit = v['units'][unit]
-            unit_status = _unit['workload-status']['current']
-            if unit_status == 'unknown':
-                unit_status = _unit['juju-status']['current']
-            agent_states.append(unit_status)
-if any([state == 'error' for state in agent_states]):
-    error('Error in one of the applications deployment')
+juju wait -m $JUJU_CONTROLLER:$JUJU_MODEL
 
-log.debug("Checking agent_states: {}".format(agent_states))
-if agent_states.count('active') == 2 and agent_states.count('idle') == 1:
-    success('Applications are ready')
-
-fail('Applications not ready yet')
+printf '{"message": "Applications Ready", "returnCode": 0, "isComplete": "true"}'
+exit 0

--- a/hadoop-processing/steps/00_deploy-done
+++ b/hadoop-processing/steps/00_deploy-done
@@ -1,35 +1,6 @@
-#!/usr/bin/env python3
-from conjureup.hooklib import juju
-from conjureup.hooklib.writer import success, fail, error
-import logging
+#!/bin/bash
 
-log = logging.getLogger('conjureup')
-NUM_AGENTS = 8
+juju wait -m $JUJU_CONTROLLER:$JUJU_MODEL
 
-
-log.debug("Running deploy-done for Apache Hadoop installation.")
-agent_states = juju.agent_states()
-
-errored_units = [(unit_name, message) for unit_name, state, message
-                 in agent_states if state == "error"]
-if len(errored_units) > 0:
-    errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_units])
-    error('Deployment errors:\n{}'.format(errs))
-
-machines = juju.machine_states()
-errored_machines = [(name, err) for name, status, err in machines
-                    if status == "error"]
-if len(errored_machines) > 0:
-    errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_machines])
-    error("Machine creation errors:\n{}".format(errs))
-
-if len(agent_states) < NUM_AGENTS:
-    fail('{} applications are still deploying'.format(
-        NUM_AGENTS - len(agent_states)))
-
-active_states = [state == 'active' for _, state, _ in agent_states
-                 if state != 'unknown']
-if len(active_states) > 0 and all(active_states):
-    success('Applications are ready')
-
-fail('Applications not ready yet')
+printf '{"message": "Applications Ready", "returnCode": 0, "isComplete": "true"}'
+exit 0

--- a/kubernetes-core/steps/00_deploy-done
+++ b/kubernetes-core/steps/00_deploy-done
@@ -1,24 +1,6 @@
-#!/usr/bin/env python3
-from conjureup.hooklib.writer import success, fail, error
-from conjureup.hooklib import juju
-import logging
+#!/bin/bash
 
-log = logging.getLogger('conjureup')
+juju wait -m $JUJU_CONTROLLER:$JUJU_MODEL
 
-
-log.debug("Running deploy-done for Kubernetes installation.")
-
-agent_states = juju.agent_states()
-agent_states_no_es = []
-
-for row in agent_states:
-    if 'elasticsearch' not in row[0]:
-        agent_states_no_es.append(row)
-
-if any([state == 'error' for _, state, _ in agent_states]):
-    error('Error in one of the applications deployment')
-
-if all([state == 'active' for _, state, _ in agent_states_no_es]):
-    success('Applications are ready')
-
-fail('Applications not ready yet')
+printf '{"message": "Applications Ready", "returnCode": 0, "isComplete": "true"}'
+exit 0

--- a/openstack-base/steps/00_deploy-done
+++ b/openstack-base/steps/00_deploy-done
@@ -1,27 +1,6 @@
-#!/usr/bin/env python3
-from conjureup.hooklib.writer import success, fail, error, log
-from conjureup.hooklib import juju
+#!/bin/bash
 
-log.debug("Running deploy-done for OpenStack installation.")
-agent_states = juju.agent_states()
+juju wait -m $JUJU_CONTROLLER:$JUJU_MODEL
 
-errored_units = [(unit_name, message) for unit_name, state, message
-                 in agent_states if state == "error"]
-if len(errored_units) > 0:
-    errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_units])
-    error('Deployment errors:\n{}'.format(errs))
-
-machines = juju.machine_states()
-errored_machines = [(name, err) for name, status, err in machines
-                    if status == "error"]
-if len(errored_machines) > 0:
-    errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_machines])
-    error("Machine creation errors:\n{}".format(errs))
-
-if len(agent_states) == 0:
-    fail('Applications are still deploying')
-
-if all([state == 'active' for _, state, _ in agent_states]):
-    success('Applications are ready')
-
-fail('Applications not ready yet')
+printf '{"message": "Applications Ready", "returnCode": 0, "isComplete": "true"}'
+exit 0

--- a/openstack-novalxd/steps/00_deploy-done
+++ b/openstack-novalxd/steps/00_deploy-done
@@ -1,27 +1,6 @@
-#!/usr/bin/env python3
-from conjureup.hooklib.writer import success, fail, error, log
-from conjureup.hooklib import juju
+#!/bin/bash
 
-log.debug("Running deploy-done for OpenStack installation.")
-agent_states = juju.agent_states()
+juju wait -m $JUJU_CONTROLLER:$JUJU_MODEL
 
-errored_units = [(unit_name, message) for unit_name, state, message
-                 in agent_states if state == "error"]
-if len(errored_units) > 0:
-    errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_units])
-    error('Deployment errors:\n{}'.format(errs))
-
-machines = juju.machine_states()
-errored_machines = [(name, err) for name, status, err in machines
-                    if status == "error"]
-if len(errored_machines) > 0:
-    errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_machines])
-    error("Machine creation errors:\n{}".format(errs))
-
-if len(agent_states) == 0:
-    fail('Applications are still deploying')
-
-if all([state == 'active' for _, state, _ in agent_states]):
-    success('Applications are ready')
-
-fail('Applications not ready yet')
+printf '{"message": "Applications Ready", "returnCode": 0, "isComplete": "true"}'
+exit 0

--- a/realtime-syslog-analytics/steps/00_deploy-done
+++ b/realtime-syslog-analytics/steps/00_deploy-done
@@ -1,33 +1,6 @@
-#!/usr/bin/env python3
-from conjureup.hooklib.writer import success, fail, error, log
-from conjureup.hooklib import juju
+#!/bin/bash
 
-NUM_AGENTS = 8
+juju wait -m $JUJU_CONTROLLER:$JUJU_MODEL
 
-log.debug("Running deploy-done for Realtime "
-          "syslog analytics installation.")
-agent_states = juju.agent_states()
-
-errored_units = [(unit_name, message) for unit_name, state, message
-                 in agent_states if state == "error"]
-if len(errored_units) > 0:
-    errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_units])
-    error('Deployment errors:\n{}'.format(errs))
-
-machines = juju.machine_states()
-errored_machines = [(name, err) for name, status, err in machines
-                    if status == "error"]
-if len(errored_machines) > 0:
-    errs = "\n".join(["{}: {}".format(n, m) for n, m in errored_machines])
-    error("Machine creation errors:\n{}".format(errs))
-
-if len(agent_states) < NUM_AGENTS:
-    fail('{} applications are still deploying'.format(
-        NUM_AGENTS - len(agent_states)))
-
-active_states = [state == 'active' for _, state, _ in agent_states
-                 if state != 'unknown']
-if len(active_states) > 0 and all(active_states):
-    success('Applications are ready')
-
-fail('Applications not ready yet')
+printf '{"message": "Applications Ready", "returnCode": 0, "isComplete": "true"}'
+exit 0


### PR DESCRIPTION
With the release of pure snaps for conjure-up we've added another python
dependency `juju_wait`. This allows us to monitor deployments for when hook
firing becomes idle and then moving onto the post processing steps.

This is a much better solution then counting initial agents and checking their
workload/agent status.

We need to make the ppa distributions point to users installing the new snap way
as juju-wait is not available in the ppa or any archive and is only brought in
during the snap build phase.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>