### PR TITLE
Have juju-wait detect hook failures

### DIFF
--- a/ghost/steps/00_deploy-done
+++ b/ghost/steps/00_deploy-done
@@ -10,6 +10,8 @@ SCRIPTPATH=$(dirname $SCRIPT)
 
 . $CONJURE_UP_SPELLSDIR/sdk/common.sh
 
-juju wait -m $JUJU_CONTROLLER:$JUJU_MODEL
+if ! juju wait -wm $JUJU_CONTROLLER:$JUJU_MODEL; then
+    exposeResult "Applications did not start successfully" 1 "false"
+fi
 
 exposeResult "Applications Ready" 0 "true"


### PR DESCRIPTION
Without this option, conjure-up tells the user that everything is fine even if a unit is in error.  With this change, it does this instead:

```
[info] Summoning ./ghost to localhost
[info] Using controller 'lxd'
[info] Creating new deployment named 'conjure-up-ghost-cfd', please wait.
[info] Deploying ghost...
[info] Deploying haproxy...
[info] Deploying mysql...
[info] haproxy: deployed, installing.
[info] mysql: deployed, installing.
[info] ghost: deployed, installing.
[info] Setting application relations
[info] Completed setting application relations
[info] Waiting for applications to start
[error] Applications did not start successfully
```