### PR TITLE
Fix CDK pre-deploy error if existing but unselected controller is chosen

### DIFF
--- a/canonical-kubernetes/steps/00_pre-deploy
+++ b/canonical-kubernetes/steps/00_pre-deploy
@@ -10,7 +10,7 @@ if [[ "$JUJU_PROVIDERTYPE" == "lxd" ]]; then
 fi
 
 cluster_tag="$JUJU_MODEL-$(pwgen -0AB 4 1)"
-juju model-config resource-tags="KubernetesCluster=$cluster_tag" cdk-tag="$cluster_tag"
+juju model-config -m "$JUJU_CONTROLLER:$JUJU_MODEL" resource-tags="KubernetesCluster=$cluster_tag" cdk-tag="$cluster_tag"
 
 setResult "Successful pre-deploy."
 exit 0


### PR DESCRIPTION
Fixes this error:

```
+ juju model-config resource-tags=KubernetesCluster=conjure-canonical-kubern-e01-mgbt cdk-tag=conjure-canonical-kubern-e01-mgbt
ERROR opening API connection: No selected controller.

Please use "juju switch" to select a controller.
```