### PR TITLE
Feature/cleaner k8s config

### DIFF
--- a/canonical-kubernetes/steps/step-01_get-kubectl
+++ b/canonical-kubernetes/steps/step-01_get-kubectl
@@ -7,8 +7,8 @@ set -eu
 mkdir -p $HOME/.kube
 mkdir -p $HOME/bin
 
-cmd_to_run="~/bin/kubectl.$JUJU_MODEL"
-juju scp -m $JUJU_CONTROLLER:$JUJU_MODEL kubernetes-master/0:config ~/.kube/config.$JUJU_MODEL
+kubeconfig_path=$(autoincrFile "$HOME/.kube/config")
+juju scp -m "$JUJU_CONTROLLER:$JUJU_MODEL" kubernetes-master/0:config "~/.kube/$kubeconfig_path"
 
 if [[ $(uname -s) = "Darwin" ]]; then
     repo=https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/
@@ -23,8 +23,6 @@ else
     sudo snap install kubefed --classic || true
 fi
 
-echo "kubectl --kubeconfig=$HOME/.kube/config.$JUJU_MODEL \$@" > $HOME/bin/kubectl.$JUJU_MODEL
-chmod +x $HOME/bin/kubectl.$JUJU_MODEL
-
-setResult "The Kubernetes client utility is now available at '$cmd_to_run'"
+latest_config_filename="${kubeconfig_path##*/}"
+setResult "The Kubernetes client utility is now available, append this clusters config with 'export KUBECONFIG=$KUBECONFIG:$latest_config_filename'"
 exit 0

--- a/canonical-kubernetes/steps/step-01_get-kubectl
+++ b/canonical-kubernetes/steps/step-01_get-kubectl
@@ -8,7 +8,11 @@ mkdir -p $HOME/.kube
 mkdir -p $HOME/bin
 
 kubeconfig_path=$(autoincrFile "$HOME/.kube/config")
-juju scp -m "$JUJU_CONTROLLER:$JUJU_MODEL" kubernetes-master/0:config "~/.kube/$kubeconfig_path"
+juju scp -m "$JUJU_CONTROLLER:$JUJU_MODEL" kubernetes-master/0:config "$kubeconfig_path"
+
+# Create a unique context for this config
+hash=$(genHash)
+sed -i "s/juju-context/juju-context-$hash/g" "$kubeconfig_path"
 
 if [[ $(uname -s) = "Darwin" ]]; then
     repo=https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/

--- a/canonical-kubernetes/steps/step-01_get-kubectl
+++ b/canonical-kubernetes/steps/step-01_get-kubectl
@@ -28,5 +28,6 @@ else
 fi
 
 latest_config_filename="${kubeconfig_path##*/}"
+redis-cli set "conjure-up.$CONJURE_UP_SPELL.latest_config_filename" "$latest_config_filename"
 setResult "The Kubernetes client utility is now available, run with \`kubectl --kubeconfig=\$HOME/.kube/$latest_config_filename\`"
 exit 0

--- a/canonical-kubernetes/steps/step-01_get-kubectl
+++ b/canonical-kubernetes/steps/step-01_get-kubectl
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu
+set -eux
 
 . $CONJURE_UP_SPELLSDIR/sdk/common.sh
 
@@ -28,5 +28,5 @@ else
 fi
 
 latest_config_filename="${kubeconfig_path##*/}"
-setResult "The Kubernetes client utility is now available, append this clusters config with 'export KUBECONFIG=$KUBECONFIG:$latest_config_filename'"
+setResult "The Kubernetes client utility is now available, run with \`kubectl --kubeconfig=\$HOME/.kube/$latest_config_filename\`"
 exit 0

--- a/canonical-kubernetes/steps/step-02_cluster-info
+++ b/canonical-kubernetes/steps/step-02_cluster-info
@@ -4,7 +4,9 @@ set -eu
 
 . "$CONJURE_UP_SPELLSDIR/sdk/common.sh"
 
-INFO="$(~/bin/kubectl.$JUJU_MODEL cluster-info | perl -p -e 's/\n/\\n/'| perl -pe 's/\x1b\[[0-9;]*m//g')"
+kubeconfig=$(redis-cli get "conjure-up.$CONJURE_UP_SPELL.latest_config_filename")
+
+INFO="$(kubectl --kubeconfig="$kubeconfig" cluster-info | perl -p -e 's/\n/\\n/'| perl -pe 's/\x1b\[[0-9;]*m//g')"
 
 setResult "$INFO"
 exit 0

--- a/canonical-kubernetes/steps/step-02_cluster-info
+++ b/canonical-kubernetes/steps/step-02_cluster-info
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-set -eu
+set -eux
 
 . "$CONJURE_UP_SPELLSDIR/sdk/common.sh"
 
 kubeconfig=$(redis-cli get "conjure-up.$CONJURE_UP_SPELL.latest_config_filename")
 
-INFO="$(kubectl --kubeconfig="$kubeconfig" cluster-info | perl -p -e 's/\n/\\n/'| perl -pe 's/\x1b\[[0-9;]*m//g')"
+INFO="$(kubectl --kubeconfig=$HOME/.kube/$kubeconfig cluster-info | perl -pe 's/\x1b\[[0-9;]*m//g')"
 
 setResult "$INFO"
 exit 0

--- a/sdk/common.sh
+++ b/sdk/common.sh
@@ -283,3 +283,19 @@ setResult()
 {
     redis-cli set "conjure-up.$CONJURE_UP_SPELL.$CONJURE_UP_STEP.result" "$1"
 }
+
+# autoincrements a file as to not overwrite existing ones
+#
+# Arguments:
+# $1: path to file
+autoincrFile()
+{
+name="$1"
+if [[ -e "$name" ]] ; then
+    i=0
+    while [[ -e "$name-$i" ]] ; do
+        let i++
+    done
+    printf "$name-$i"
+fi
+}

--- a/sdk/common.sh
+++ b/sdk/common.sh
@@ -155,75 +155,6 @@ unitMachine()
     juju status -m "$JUJU_CONTROLLER:$JUJU_MODEL" --format json | jq -r ".applications[\"$1\"][\"units\"][\"$1/$2\"][\"machine\"]"
 }
 
-# Waits for machine to start
-#
-# Arguments:
-# machine: machine number
-waitForMachine()
-{
-    for machine; do
-        while [ "$(agentState $machine)" != started ]; do
-            sleep 5
-        done
-    done
-}
-
-# Waits for service to start
-#
-# Arguments:
-# service: service name
-waitForService()
-{
-
-    for service; do
-        while [ "$(agentStateUnit "$service" 0)" != active ]; do
-            sleep 5
-        done
-    done
-}
-
-# Parses result into json output
-#
-# Arguments:
-# $1: return message
-# $2: return code
-# $3: true/false
-exposeResult()
-{
-    printf '{"message": "%s", "returnCode": %d, "isComplete": %s}' "$1" "$2" "$3"
-    exit 0
-}
-
-# Checks an array of applications for an error flag
-#
-# Arguments:
-# $1: array of applications
-checkUnitsForErrors() {
-    applications=$1
-    for i in "${applications[@]}"
-    do
-        if [ $(unitStatus "$i" 0) = "error" ]; then
-            debug "$i, gave a charm error."
-            exposeResult "Error with $i, please check juju status" 1 "false"
-        fi
-    done
-}
-
-# Checks an array of applications for an active flag
-#
-# Arguments:
-# $1: array of applications
-checkUnitsForActive() {
-    applications=$1
-    for i in "${applications[@]}"
-    do
-        debug "Checking agent state of $i: $(unitStatus $i 0)"
-        if [ $(unitStatus "$i" 0) != "active" ]; then
-            exposeResult "$i not quite ready yet" 0 "false"
-        fi
-    done
-}
-
 # Safely expands tilde paths
 #
 # Arguments:
@@ -290,12 +221,20 @@ setResult()
 # $1: path to file
 autoincrFile()
 {
-name="$1"
-if [[ -e "$name" ]] ; then
-    i=0
-    while [[ -e "$name-$i" ]] ; do
-        let i++
-    done
-    printf "$name-$i"
-fi
+    name="$1"
+    if [[ -e "$name" ]] ; then
+        i=0
+        while [[ -e "$name-$i" ]] ; do
+            let i++
+        done
+        printf "$name-$i"
+    fi
+}
+
+# uuidgen printing first 3 characters
+genHash()
+{
+    local sha
+    sha=$(uuidgen | cut -d- -f1)
+    printf "${sha:0:3}"
 }


### PR DESCRIPTION
This autoincrements the `~/.kube/config` filename if one exists, and instructs the user to pass in `--kubeconfig=$HOME/.kube/config-X`.  It's possible to handle multiple configs like this by passing in:

```
KUBECONFIG=$HOME/.kube/config:$HOME/.kube/config-1 kubectl config get-contexts
```

Some drive-by cleanup of old shell code that isn't used any longer.

Here is the output of the latest k8s-core with this updated spell, and already have a `config,config-0,config-1,config-2` file.

```
[info] Running step: step-03_enable-cni.
[info] Creating IAM policy: juju-kubernetes-master

[info] Creating IAM policy: juju-kubernetes-worker

[info] Creating IAM role: juju-kubernetes-master

[info] Creating IAM role: juju-kubernetes-worker

[info] Creating instance profile: juju-kubernetes-master

[info] Creating instance profile: juju-kubernetes-worker

[info] Attaching IAM policy juju-kubernetes-master to IAM role juju-kubernetes-master

[info] Attaching IAM policy juju-kubernetes-worker to IAM role juju-kubernetes-worker

[info] Adding IAM role juju-kubernetes-master to instance profile juju-kubernetes-master

[info] Adding IAM role juju-kubernetes-worker to instance profile juju-kubernetes-worker

[info] Attaching instance profile juju-kubernetes-master to i-034129efbd46f68d3

[info] Attaching instance profile juju-kubernetes-worker to i-0b546b7129258463a

[info] Removing KubernetesCluster tag from shared security group for kubernetes-master

[info] Removing KubernetesCluster tag from shared security group for kubernetes-worker

[info] Tagging kubernetes-master with KubernetesCluster=conjure-k8s-booyaka-wqrb

[info] Tagging kubernetes-worker with KubernetesCluster=conjure-k8s-booyaka-wqrb

[info] Tagging kubernetes-worker subnets with KubernetesCluster=conjure-k8s-booyaka-wqrb

[info] Configuring cloud-provider for kube-apiserver

[info] Configuring cloud-provider for kube-controller-manager

[info] Configuring cloud-provider for kubelet

[info] Post-Deployment Step Results
+---------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
|           Application           |                                                             Result                                                             |
+---------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
|  Kubernetes Cluster Controller  |              The Kubernetes client utility is now available, run with `kubectl --kubeconfig=$HOME/.kube/config-3`              |
| Kubernetes Cluster Status Check |                                   Kubernetes master is running at https://18.220.1.103:6443                                    |
|                                 |             Heapster is running at https://18.220.1.103:6443/api/v1/namespaces/kube-system/services/heapster/proxy             |
|                                 |             KubeDNS is running at https://18.220.1.103:6443/api/v1/namespaces/kube-system/services/kube-dns/proxy              |
|                                 | kubernetes-dashboard is running at https://18.220.1.103:6443/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy |
|                                 |        Grafana is running at https://18.220.1.103:6443/api/v1/namespaces/kube-system/services/monitoring-grafana/proxy         |
|                                 |       InfluxDB is running at https://18.220.1.103:6443/api/v1/namespaces/kube-system/services/monitoring-influxdb/proxy        |
|                                 |                                                                                                                                |
|                                 |                        To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.                        |
| Enable Cloud Native Integration |                                                Cloud native integration enabled                                                |
+---------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
[info] Installation of your big software is now complete.
[warning] Shutting down

```