### PR TITLE
Update novalxd spell to work with upcoming changes in conjure-up

### DIFF
--- a/openstack-base/steps/share/glance.sh
+++ b/openstack-base/steps/share/glance.sh
@@ -5,11 +5,11 @@ imagesuffix="-kvm"
 mkdir -p $HOME/glance-images || true
 if [ ! -f $HOME/glance-images/xenial-server-cloudimg-amd64-$imagetype ]; then
     debug "Downloading xenial image..."
-    wget -qO ~/glance-images/xenial-server-cloudimg-amd64-$imagetype https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-$imagetype
+    wget --user-agent="conjure-up/openstack-novalxd" -qO ~/glance-images/xenial-server-cloudimg-amd64-$imagetype https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-$imagetype
 fi
 if [ ! -f $HOME/glance-images/trusty-server-cloudimg-amd64-$imagetype ]; then
     debug "Downloading trusty image..."
-    wget -qO ~/glance-images/trusty-server-cloudimg-amd64-$imagetype https://cloud-images.ubuntu.com/trusty/current/trusty-server-cloudimg-amd64-$imagetype
+    wget --user-agent="conjure-up/openstack-novalxd" -qO ~/glance-images/trusty-server-cloudimg-amd64-$imagetype https://cloud-images.ubuntu.com/trusty/current/trusty-server-cloudimg-amd64-$imagetype
 fi
 
 if ! glance image-list --property-filter name="trusty$imagesuffix" | grep -q "trusty$imagesuffix" ; then

--- a/openstack-novalxd/steps/00_pre-deploy
+++ b/openstack-novalxd/steps/00_pre-deploy
@@ -6,7 +6,30 @@ set -eux
 
 if [[ "$JUJU_PROVIDERTYPE" == "localhost" ]]; then
     debug "Running pre-deploy for $CONJURE_UP_SPELL"
-    sed "s/##MODEL##/$JUJU_MODEL/" $(scriptPath)/lxd-profile.yaml | lxc profile edit "juju-$JUJU_MODEL"
+    NETWORK=$(getKey "lxd-network-name")
+    STORAGE_POOL=$(getKey "lxd-storage-pool")
+    echo "Network: $(getKey "lxd-network")"
+    lxc profile edit "juju-$JUJU_MODEL" <<EOF
+name: juju-${JUJU_MODEL}
+config:
+  boot.autostart: "true"
+  security.nesting: "true"
+  security.privileged: "true"
+  linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables,netlink_diag
+  raw.lxc: |
+    lxc.aa_profile=unconfined
+    lxc.mount.auto=sys:rw
+devices:
+  eth0:
+    nictype: bridged
+    parent: ${NETWORK}
+    type: nic
+  root:
+    path: /
+    pool: ${STORAGE_POOL}
+    type: disk
+EOF
+    lxc network create conjureup0 ipv6.address=none ipv4.address=10.101.0.1/24 ipv4.nat=true || echo "conjureup0 network already exists" && true
 fi
 
 setResult "Successful pre-deploy."

--- a/openstack-novalxd/steps/00_pre-deploy
+++ b/openstack-novalxd/steps/00_pre-deploy
@@ -9,6 +9,8 @@ if [[ "$JUJU_PROVIDERTYPE" == "localhost" ]]; then
     NETWORK=$(getKey "lxd-network-name")
     STORAGE_POOL=$(getKey "lxd-storage-pool")
     echo "Network: $(getKey "lxd-network")"
+    lxc network create conjureup0 ipv6.address=none ipv4.address=10.101.0.1/24 ipv4.nat=true || echo "conjureup0 network already exists" && true
+
     lxc profile edit "juju-$JUJU_MODEL" <<EOF
 name: juju-${JUJU_MODEL}
 config:
@@ -24,12 +26,15 @@ devices:
     nictype: bridged
     parent: ${NETWORK}
     type: nic
+  eth1:
+    nictype: bridged
+    parent: conjureup0
+    type: nic
   root:
     path: /
     pool: ${STORAGE_POOL}
     type: disk
 EOF
-    lxc network create conjureup0 ipv6.address=none ipv4.address=10.101.0.1/24 ipv4.nat=true || echo "conjureup0 network already exists" && true
 fi
 
 setResult "Successful pre-deploy."

--- a/openstack-novalxd/steps/share/neutron.sh
+++ b/openstack-novalxd/steps/share/neutron.sh
@@ -12,9 +12,9 @@ fi
 
 if ! neutron subnet-show ext-subnet > /dev/null 2>&1; then
     debug "adding ext-subnet"
-    if ! neutron subnet-create --name ext-subnet ext-net 10.99.0.0/24 \
-             --gateway 10.99.0.1 --disable-dhcp \
-             --allocation-pool start=10.99.0.3,end=10.99.0.254 > /dev/null 2>&1; then
+    if ! neutron subnet-create --name ext-subnet ext-net "$LXD_NETWORK" \
+             --gateway "$LXD_GATEWAY" --disable-dhcp \
+             --allocation-pool start="$LXD_DHCP_RANGE_START",end="$LXD_DHCP_RANGE_STOP" > /dev/null 2>&1; then
         debug "could not subnet-create ext-subnet"
     fi
 fi

--- a/openstack-novalxd/steps/step-04_neutron
+++ b/openstack-novalxd/steps/step-04_neutron
@@ -5,6 +5,18 @@
 tmpfile=$(mktemp)
 
 $(scriptPath)/share/novarc > "$tmpfile"
+
+LXD_NETWORK=$(getKey "lxd-network-name")
+LXD_GATEWAY=$(getKey "lxd-network-gateway")
+LXD_DHCP_RANGE_START=$(getKey "lxd-network-dhcp-range-start")
+LXD_DHCP_RANGE_STOP=$(getKey "lxd-network-dhcp-range-stop")
+
+cat<<EOF>> "$tmpfile"
+export LXD_NETWORK=${LXD_NETWORK}
+export LXD_GATEWAY=${LXD_GATEWAY}
+export LXD_DHCP_RANGE_START=${LXD_DHCP_RANGE_START}
+export LXD_DHCP_RANGE_STOP=${LXD_DHCP_RANGE_STOP}
+EOF
 cat $(scriptPath)/share/common.sh >> "$tmpfile"
 cat $(scriptPath)/share/neutron.sh >> "$tmpfile"
 

--- a/openstack-novalxd/steps/step-04_neutron
+++ b/openstack-novalxd/steps/step-04_neutron
@@ -7,7 +7,7 @@ tmpfile=$(mktemp)
 $(scriptPath)/share/novarc > "$tmpfile"
 
 LXD_NETWORK=$(getKey "lxd-network-name")
-LXD_GATEWAY=$(getKey "lxd-network-gateway")
+LXD_GATEWAY=$(getKey "lxd-gateway")
 LXD_DHCP_RANGE_START=$(getKey "lxd-network-dhcp-range-start")
 LXD_DHCP_RANGE_STOP=$(getKey "lxd-network-dhcp-range-stop")
 


### PR DESCRIPTION
For lxd setups we are storing additional information in our state server such as network name, gateway, dhcp ranges. This patch makes use of that capability and also fixing neutron containing an incorrect network.