### PR TITLE
Support arm64 images.

### DIFF
--- a/openstack-base/steps/share/glance.sh
+++ b/openstack-base/steps/share/glance.sh
@@ -1,33 +1,57 @@
-imagetype=disk1.img
-diskformat=raw
+sudo apt update > /dev/null 2>&1
+sudo apt -qyf install python3-openstackclient > /dev/null 2>&1
+
 imagesuffix="-kvm"
+declare -A arches=(["aarch64"]="arm64" ["x86_64"]="amd64")
+declare -A imagetypes=(["aarch64"]="uefi1.img" ["x86_64"]="disk1.img")
+declare -A diskformats=(["aarch64"]="qcow2" ["x86_64"]="raw")
+declare -A firmwaretypes=(["aarch64"]="uefi" ["x86_64"]="bios")
+
+nova_architectures=$( \
+    for id in $(openstack hypervisor list | grep -o " [0-9]\+ "); \
+    do
+        openstack hypervisor show -c cpu_info $id | \
+            cut -f 3 -d '|' | tail -n +4 | head -n 1 | jq -r ".arch"
+    done | uniq)
 
 mkdir -p $HOME/glance-images || true
-if [ ! -f $HOME/glance-images/xenial-server-cloudimg-amd64-$imagetype ]; then
-    debug "Downloading xenial image..."
-    wget --user-agent="conjure-up/openstack-novalxd" -qO ~/glance-images/xenial-server-cloudimg-amd64-$imagetype https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-$imagetype
-fi
-if [ ! -f $HOME/glance-images/trusty-server-cloudimg-amd64-$imagetype ]; then
-    debug "Downloading trusty image..."
-    wget --user-agent="conjure-up/openstack-novalxd" -qO ~/glance-images/trusty-server-cloudimg-amd64-$imagetype https://cloud-images.ubuntu.com/trusty/current/trusty-server-cloudimg-amd64-$imagetype
-fi
 
-if ! glance image-list --property-filter name="trusty$imagesuffix" | grep -q "trusty$imagesuffix" ; then
-    debug "Importing trusty$imagesuffix"
-    glance image-create --name="trusty$imagesuffix" \
-           --container-format=bare \
-           --disk-format=$diskformat \
-           --property architecture="x86_64" \
-           --visibility=public --file=$HOME/glance-images/trusty-server-cloudimg-amd64-$imagetype > /dev/null 2>&1
-fi
-if ! glance image-list --property-filter name="xenial$imagesuffix" | grep -q "xenial$imagesuffix" ; then
-    debug "Importing xenial$imagesuffix"
-    glance image-create --name="xenial$imagesuffix" \
-           --container-format=bare \
-           --disk-format=$diskformat \
-           --property architecture="x86_64" \
-           --visibility=public --file=$HOME/glance-images/xenial-server-cloudimg-amd64-$imagetype > /dev/null 2>&1
-fi
+for nova_arch in $nova_architectures;
+do
+    image_arch=${arches[$nova_arch]}
+    imagetype=${imagetypes[$nova_arch]}
+    diskformat=${diskformats[$nova_arch]}
+    firmwaretype=${firmwaretypes[$nova_arch]}
+    if [ ! -f $HOME/glance-images/xenial-server-cloudimg-${image_arch}-$imagetype ]; then
+        debug "Downloading xenial image..."
+        wget --user-agent="conjure-up/openstack-novalxd" -qO ~/glance-images/xenial-server-cloudimg-${image_arch}-$imagetype https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-${image_arch}-$imagetype
+    fi
+    if [ ! -f $HOME/glance-images/trusty-server-cloudimg-${image_arch}-$imagetype ]; then
+        debug "Downloading trusty image..."
+        wget --user-agent="conjure-up/openstack-novalxd" -qO ~/glance-images/trusty-server-cloudimg-${image_arch}-$imagetype https://cloud-images.ubuntu.com/trusty/current/trusty-server-cloudimg-${image_arch}-$imagetype
+    fi
+
+    trusty_image=trusty${imagesuffix}-${image_arch}
+    if ! glance image-list --property-filter name="$trusty_image" | grep -q "$trusty_image" ; then
+        debug "Importing $trusty_image"
+        glance image-create --name="$trusty_image" \
+               --container-format=bare \
+               --disk-format=$diskformat \
+               --property hw_firmware_type=$firmwaretype \
+               --property architecture="${nova_arch}" \
+               --visibility=public --file=$HOME/glance-images/trusty-server-cloudimg-${image_arch}-$imagetype > /dev/null 2>&1
+    fi
+    xenial_image=xenial${imagesuffix}-${image_arch}
+    if ! glance image-list --property-filter name="$xenial_image" | grep -q "$xenial_image" ; then
+        debug "Importing $xenial_image"
+        glance image-create --name="$xenial_image" \
+               --container-format=bare \
+               --disk-format=$diskformat \
+               --property hw_firmware_type=$firmwaretype \
+               --property architecture="${nova_arch}" \
+               --visibility=public --file=$HOME/glance-images/xenial-server-cloudimg-${image_arch}-$imagetype > /dev/null 2>&1
+    fi
+done
 
 printf "Glance images for Trusty (14.04) and Xenial (16.04) are imported and accessible via Horizon dashboard."
 exit 0

--- a/openstack-base/steps/step-03_keypair
+++ b/openstack-base/steps/step-03_keypair
@@ -8,11 +8,6 @@ debug "Environment Variables: $_ssh_public_key"
 tmpfile=$(mktemp)
 debug "Created tmpfile: $tmpfile"
 
-cat <<EOF> $tmpfile
-sudo apt update > /dev/null 2>&1
-sudo apt -qyf install python3-openstackclient > /dev/null 2>&1
-EOF
-
 # write credentials
 $(scriptPath)/share/novarc >> $tmpfile
 


### PR DESCRIPTION
arm64 uses UEFI images, but that doesn't work on amd64 with current
packaging, so we only want UEFI for arm64.