### PR TITLE
Install jq before using it in glance.sh.

### DIFF
--- a/openstack-base/steps/share/glance.sh
+++ b/openstack-base/steps/share/glance.sh
@@ -1,5 +1,5 @@
 sudo apt update > /dev/null 2>&1
-sudo apt -qyf install python3-openstackclient > /dev/null 2>&1
+sudo apt -qyf install python3-openstackclient jq > /dev/null 2>&1
 
 imagesuffix="-kvm"
 declare -A arches=(["aarch64"]="arm64" ["x86_64"]="amd64")


### PR DESCRIPTION
jq isn't always installed on the system where the glance commands are running (nova-cloud-controller/0).  This makes sure it's there before trying to use it.