### PR TITLE
Create addon aliases that provide underlying spell

### DIFF
--- a/addons-aliases.yaml
+++ b/addons-aliases.yaml
@@ -1,0 +1,6 @@
+deis:
+  spell: canonical-kubernetes
+  addons: [deis]
+helm:
+  spell: canonical-kubernetes
+  addons: [helm]


### PR DESCRIPTION
This lets a user type `conjure-up deis` and know that the base
spell required is `canonical-kubernetes`

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>