### PR TITLE
disable ES firewall

### DIFF
--- a/hadoop-processing/steps/01_logging/elg.yaml
+++ b/hadoop-processing/steps/01_logging/elg.yaml
@@ -4,6 +4,8 @@ services:
   elasticsearch:
     charm: cs:xenial/elasticsearch
     num_units: 1
+    options:
+      firewall_enabled: false
   graylog:
     charm: cs:xenial/graylog
     num_units: 1

--- a/hadoop-processing/steps/02_monitoring/elasticbeats.yaml
+++ b/hadoop-processing/steps/02_monitoring/elasticbeats.yaml
@@ -4,6 +4,8 @@ services:
   elasticsearch:
     charm: cs:xenial/elasticsearch
     num_units: 1
+    options:
+      firewall_enabled: false
 relations:
   - ["topbeat:elasticsearch", "elasticsearch:client"]
   - ["topbeat:beats-host", "namenode:juju-info"]

--- a/spark-processing/steps/01_logging/elg.yaml
+++ b/spark-processing/steps/01_logging/elg.yaml
@@ -4,6 +4,8 @@ services:
   elasticsearch:
     charm: cs:xenial/elasticsearch
     num_units: 1
+    options:
+      firewall_enabled: false
   graylog:
     charm: cs:xenial/graylog
     num_units: 1

--- a/spark-processing/steps/02_monitoring/elasticbeats.yaml
+++ b/spark-processing/steps/02_monitoring/elasticbeats.yaml
@@ -4,6 +4,8 @@ services:
   elasticsearch:
     charm: cs:xenial/elasticsearch
     num_units: 1
+    options:
+      firewall_enabled: false
 relations:
   - ["topbeat:elasticsearch", "elasticsearch:client"]
   - ["topbeat:beats-host", "spark:juju-info"]


### PR DESCRIPTION
There's an issue when client-relation-changed calls ansible-playbook:

https://bugs.launchpad.net/elasticsearch-charm/+bug/1714393

Work around this by disabling the ES firewall, which is ok in our case
because we dont expose the ES charm.

This means ES will be accessible to other applications in the deployment, but
it will remain inaccessible to the outside until an operator chooses to
expose it.