### PR TITLE
Replace charmhelpers with kv

### DIFF
--- a/sdk/common.sh
+++ b/sdk/common.sh
@@ -303,7 +303,7 @@ getStepKey()
 # $2: VALUE
 setKey()
 {
-    chlp unitdata set "conjure-up.$CONJURE_UP_SPELL.$1" "$2"
+    kv-cli "$KV_DB" set "conjure-up.$CONJURE_UP_SPELL.$1" "$2"
 }
 
 # gets a state key/value namespaced by the current spell
@@ -312,5 +312,5 @@ setKey()
 # $1: KEY
 getKey()
 {
-    chlp unitdata get "conjure-up.$CONJURE_UP_SPELL.$1"
+    kv-cli "$KV_DB" get "conjure-up.$CONJURE_UP_SPELL.$1"
 }


### PR DESCRIPTION
The charmhelpers library contains a lot more code than we need, since we only use the sqlite-backed KV store, and it doesn't work on Mac OS.

Fixes #116