### PR TITLE
add hadoop-spark, ditch promreg in favor of direct telegraf-prometheus relation

### DIFF
--- a/hadoop-processing/steps/01_logging/efg.yaml
+++ b/hadoop-processing/steps/01_logging/efg.yaml
@@ -30,8 +30,8 @@ relations:
   - ["apache2:reverseproxy", "graylog:website"]
   - ["graylog:elasticsearch", "elasticsearch:client"]
   - ["graylog:mongodb", "mongodb:database"]
-  - ["filebeat:beats-host", "namenode:juju-info"]
-  - ["filebeat:beats-host", "slave:juju-info"]
+  - ["namenode:juju-info", "filebeat:beats-host"]
+  - ["slave:juju-info", "filebeat:beats-host"]
 machines:
   "4":
     series: "xenial"

--- a/hadoop-processing/steps/01_logging/metadata.yaml
+++ b/hadoop-processing/steps/01_logging/metadata.yaml
@@ -1,4 +1,4 @@
-title: Choose Logging Application
+title: Logging Mechanism
 description: Choose the preferred logging mechanism
 viewable: True
 additional-input:

--- a/hadoop-processing/steps/02_monitoring/after-deploy
+++ b/hadoop-processing/steps/02_monitoring/after-deploy
@@ -5,23 +5,40 @@ set -eux
 . "$CONJURE_UP_SPELLSDIR/sdk/common.sh"
 
 if [[ "$MONITORPLUGIN" == "Ganglia" ]]; then
+    # Since Ganglia is not password-protected, the bundle does not expose it
+    # by default. Do it now since the user wants it.
+    juju expose ganglia
+
     ip=$(unitAddress ganglia)
     setResult "The Ganglia UI is available at: http://$ip/ganglia."
 elif [[ "$MONITORPLUGIN" == "Telegraf/Prometheus/Grafana" ]]; then
     # gather vars (stripping quotes) for later config and result message
     grafana_public_ip=$(unitAddress grafana)
     grafana_port=$(juju config grafana port | sed -e 's/"//g')
-    prom_ingress_ip=$(juju run --unit prometheus/0 'network-get target --format yaml --ingress-address' | head -1)
-    prom_port=$(juju config prometheus prometheus_registration_port | sed -e 's/"//g')
-    prom_token=$(juju config prometheus prometheus_registration_authtoken | sed -e 's/"//g')
 
-    juju config telegraf promreg_authtoken="$prom_token" \
-                         promreg_url="http://$prom_ingress_ip:$prom_port"
+    # setup grafana dashboards
     juju run-action --wait grafana/0 import-dashboard \
       dashboard="$(base64 $(scriptPath)/grafana-telegraf.json)"
 
     setResult "The Grafana UI is available at: http://$grafana_public_ip:$grafana_port. \
 Retrieve the admin password with 'juju run-action --wait grafana/0 get-admin-password'."
+else
+    setResult "Ignored unexpected monitoring input: $MONITORPLUGIN."
+
+    # NB: if we ever include a metric provider that doesn't support the
+    # prometheus:target relation, we may want to explore the prom_reg layer:
+    #  https://git.launchpad.net/~prometheus-registration-developers/prometheus-registration/+git/layer-promreg-client/tree/README.md
+    #  https://git.launchpad.net/~prometheus-registration-developers/prometheus-registration/tree/README.md
+    # For example, if telegraf didn't support a direct prometheus relation, we
+    # would configure it like this:
+    #
+    #prom_ingress_ip=$(juju run --unit prometheus/0 'network-get target --format yaml --ingress-address' | head -1)
+    #prom_port=$(juju config prometheus prometheus_registration_port | sed -e 's/"//g')
+    #prom_token=$(juju config prometheus prometheus_registration_authtoken | sed -e 's/"//g')
+    #
+    #juju config prometheus prometheus_registration_listen='0.0.0.0'
+    #juju config telegraf promreg_authtoken="$prom_token" \
+    #                     promreg_url="http://$prom_ingress_ip:$prom_port"
 fi
 
 exit 0

--- a/hadoop-processing/steps/02_monitoring/grafana-telegraf.json
+++ b/hadoop-processing/steps/02_monitoring/grafana-telegraf.json
@@ -1873,7 +1873,7 @@
       ]
     },
     "timezone": "browser",
-    "title": "Telegraf Node Metrics",
+    "title": "Node Metrics (via Telegraf)",
     "version": 4
   },
   "overwrite": false

--- a/hadoop-processing/steps/02_monitoring/metadata.yaml
+++ b/hadoop-processing/steps/02_monitoring/metadata.yaml
@@ -1,4 +1,4 @@
-title: Choose Monitoring Application
+title: Monitoring Mechanism
 description: Choose the preferred monitoring mechanism
 viewable: True
 additional-input:

--- a/hadoop-processing/steps/02_monitoring/tpg.yaml
+++ b/hadoop-processing/steps/02_monitoring/tpg.yaml
@@ -8,8 +8,6 @@ services:
   prometheus:
     charm: cs:xenial/prometheus-5
     num_units: 1
-    options:
-      prometheus_registration_listen: '0.0.0.0'
     to:
       - "5"
   telegraf:

--- a/hadoop-spark/metadata.yaml
+++ b/hadoop-spark/metadata.yaml
@@ -1,0 +1,3 @@
+friendly-name: Apache Hadoop+Spark Cluster
+version: 1
+bundle-name: hadoop-spark

--- a/hadoop-spark/steps/01_logging/after-deploy
+++ b/hadoop-spark/steps/01_logging/after-deploy
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -eux
+
+. "$CONJURE_UP_SPELLSDIR/sdk/common.sh"
+
+if [[ "$LOGGINGPLUGIN" == "Rsyslog" ]]; then
+    ip=$(unitAddress rsyslog)
+    setResult "Rsyslog is now configured. Syslog events are aggregated on: $ip"
+elif [[ "$LOGGINGPLUGIN" == "Elasticsearch/Filebeat/Graylog" ]]; then
+    # gather vars (stripping quotes) for later config and result message
+    proxy_public_ip=$(unitAddress apache2)
+    es_cluster=$(juju config elasticsearch cluster-name | sed -e 's/"//g')
+    graylog_ingress_ip=$(juju run --unit graylog/0 'network-get elasticsearch --format yaml --ingress-address' | head -1)
+
+    # Filebeat treats graylog as a logstash host.
+    # NB: The graylog charm should support a beats relation so we dont have to
+    # set this manually. Also 5044 is hard coded in graylog's log_inputs config.
+    juju config filebeat logstash_hosts="$graylog_ingress_ip:5044"
+
+    # Graylog needs a rev proxy and ES cluster name.
+    juju config apache2 vhost_http_template="$(base64 $(scriptPath)/graylog-vhost.tmpl)"
+    juju config graylog elasticsearch_cluster_name="$es_cluster"
+
+    setResult "The Graylog UI is available at: http://$proxy_public_ip/. \
+Retrieve the admin password with 'juju run-action --wait graylog/0 show-admin-password'."
+fi
+
+exit 0

--- a/hadoop-spark/steps/01_logging/after-input
+++ b/hadoop-spark/steps/01_logging/after-input
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eux
+
+. "$CONJURE_UP_SPELLSDIR/sdk/common.sh"
+
+if [[ "$LOGGINGPLUGIN" == "Elasticsearch/Filebeat/Graylog" ]]; then
+    setStepKey "bundle-remove" "rsyslog.yaml"
+    setStepKey "bundle-add" "efg.yaml"
+fi
+
+exit 0

--- a/hadoop-spark/steps/01_logging/efg.yaml
+++ b/hadoop-spark/steps/01_logging/efg.yaml
@@ -1,0 +1,42 @@
+services:
+  apache2:
+    charm: cs:xenial/apache2-22
+    num_units: 1
+    expose: true
+    options:
+      enable_modules: "headers proxy_html proxy_http"
+    to:
+      - "4"
+  elasticsearch:
+    charm: cs:xenial/elasticsearch-21
+    num_units: 1
+    options:
+      firewall_enabled: false
+    to:
+      - "5"
+  filebeat:
+    charm: cs:xenial/filebeat-7
+  graylog:
+    charm: cs:xenial/graylog-7
+    num_units: 1
+    to:
+      - "6"
+  mongodb:
+    charm: cs:xenial/mongodb-46
+    num_units: 1
+    to:
+      - "6"
+relations:
+  - ["apache2:reverseproxy", "graylog:website"]
+  - ["graylog:elasticsearch", "elasticsearch:client"]
+  - ["graylog:mongodb", "mongodb:database"]
+  - ["namenode:juju-info", "filebeat:beats-host"]
+  - ["slave:juju-info", "filebeat:beats-host"]
+  - ["spark:juju-info", "filebeat:beats-host"]
+machines:
+  "4":
+    series: "xenial"
+  "5":
+    series: "xenial"
+  "6":
+    series: "xenial"

--- a/hadoop-spark/steps/01_logging/graylog-vhost.tmpl
+++ b/hadoop-spark/steps/01_logging/graylog-vhost.tmpl
@@ -1,0 +1,10 @@
+<Location "/">
+    RequestHeader set X-Graylog-Server-URL "http://{{servername}}/api/"
+    ProxyPass http://{{graylog_web}}/
+    ProxyPassReverse http://{{graylog_web}}/
+</Location>
+
+<Location "/api/">
+    ProxyPass http://{{graylog_api}}/api/
+    ProxyPassReverse http://{{graylog_api}}/api/
+</Location>

--- a/hadoop-spark/steps/01_logging/metadata.yaml
+++ b/hadoop-spark/steps/01_logging/metadata.yaml
@@ -1,0 +1,11 @@
+title: Logging Mechanism
+description: Choose the preferred logging mechanism
+viewable: True
+additional-input:
+  - label: Logging
+    key: LOGGINGPLUGIN
+    type: choice
+    default: Rsyslog
+    choices:
+      - Rsyslog
+      - Elasticsearch/Filebeat/Graylog

--- a/hadoop-spark/steps/01_logging/rsyslog.yaml
+++ b/hadoop-spark/steps/01_logging/rsyslog.yaml
@@ -1,0 +1,8 @@
+services:
+  rsyslog: True
+  rsyslog-forwarder-ha: True
+relations:
+  - ["rsyslog-forwarder-ha:juju-info", "namenode:juju-info"]
+  - ["rsyslog-forwarder-ha:juju-info", "resourcemanager:juju-info"]
+  - ["rsyslog-forwarder-ha:juju-info", "slave:juju-info"]
+  - ["rsyslog:aggregator", "rsyslog-forwarder-ha:syslog"]

--- a/hadoop-spark/steps/02_monitoring/after-deploy
+++ b/hadoop-spark/steps/02_monitoring/after-deploy
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -eux
+
+. "$CONJURE_UP_SPELLSDIR/sdk/common.sh"
+
+if [[ "$MONITORPLUGIN" == "Ganglia" ]]; then
+    # Since Ganglia is not password-protected, the bundle does not expose it
+    # by default. Do it now since the user wants it.
+    juju expose ganglia
+
+    ip=$(unitAddress ganglia)
+    setResult "The Ganglia UI is available at: http://$ip/ganglia."
+elif [[ "$MONITORPLUGIN" == "Telegraf/Prometheus/Grafana" ]]; then
+    # gather vars (stripping quotes) for later config and result message
+    grafana_public_ip=$(unitAddress grafana)
+    grafana_port=$(juju config grafana port | sed -e 's/"//g')
+
+    # setup grafana dashboards
+    juju run-action --wait grafana/0 import-dashboard \
+      dashboard="$(base64 $(scriptPath)/grafana-telegraf.json)"
+
+    setResult "The Grafana UI is available at: http://$grafana_public_ip:$grafana_port. \
+Retrieve the admin password with 'juju run-action --wait grafana/0 get-admin-password'."
+else
+    setResult "Ignored unexpected monitoring input: $MONITORPLUGIN."
+
+    # NB: if we ever include a metric provider that doesn't support the
+    # prometheus:target relation, we may want to explore the prom_reg layer:
+    #  https://git.launchpad.net/~prometheus-registration-developers/prometheus-registration/+git/layer-promreg-client/tree/README.md
+    #  https://git.launchpad.net/~prometheus-registration-developers/prometheus-registration/tree/README.md
+    # For example, if telegraf didn't support a direct prometheus relation, we
+    # would configure it like this:
+    #
+    #prom_ingress_ip=$(juju run --unit prometheus/0 'network-get target --format yaml --ingress-address' | head -1)
+    #prom_port=$(juju config prometheus prometheus_registration_port | sed -e 's/"//g')
+    #prom_token=$(juju config prometheus prometheus_registration_authtoken | sed -e 's/"//g')
+    #
+    #juju config prometheus prometheus_registration_listen='0.0.0.0'
+    #juju config telegraf promreg_authtoken="$prom_token" \
+    #                     promreg_url="http://$prom_ingress_ip:$prom_port"
+fi
+
+exit 0

--- a/hadoop-spark/steps/02_monitoring/after-input
+++ b/hadoop-spark/steps/02_monitoring/after-input
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eux
+
+. "$CONJURE_UP_SPELLSDIR/sdk/common.sh"
+
+if [[ "$MONITORPLUGIN" == "Telegraf/Prometheus/Grafana" ]]; then
+    setStepKey "bundle-remove" "ganglia.yaml"
+    setStepKey "bundle-add" "tpg.yaml"
+fi
+
+exit 0

--- a/hadoop-spark/steps/02_monitoring/ganglia.yaml
+++ b/hadoop-spark/steps/02_monitoring/ganglia.yaml
@@ -1,0 +1,8 @@
+services:
+  ganglia: True
+  ganglia-node: True
+relations:
+  - ["ganglia-node:juju-info", "namenode:juju-info"]
+  - ["ganglia-node:juju-info", "resourcemanager:juju-info"]
+  - ["ganglia-node:juju-info", "slave:juju-info"]
+  - ["ganglia:node", "ganglia-node:node"]

--- a/hadoop-spark/steps/02_monitoring/grafana-telegraf.json
+++ b/hadoop-spark/steps/02_monitoring/grafana-telegraf.json
@@ -1,0 +1,1880 @@
+{
+  "dashboard": {
+    "annotations": {
+      "list": []
+    },
+    "description": "Derived from https://grafana.com/dashboards/941",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": null,
+    "links": [],
+    "rows": [
+      {
+        "collapse": false,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 2,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "system_load5{host=~\"$node\"} ",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Node load average 5m",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 3,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "system_load15{host=~\"$node\"} ",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Node load average 15m",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 1,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "system_load1{host=~\"$node\"} ",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Node load average 1m",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "Load average",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 4,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "processes_running{host=~\"$node\"} ",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Process running",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 5,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "processes_stopped{host=~\"$node\"} ",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Process stopped",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 6,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "processes_paging{host=~\"$node\"} ",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Process waiting",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "Processes statistics",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 7,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "cpu_usage_steal{cpu=\"cpu-total\", host=~\"$node\"}",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU steal",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 8,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "cpu_usage_iowait{cpu=\"cpu-total\", host=~\"$node\"}",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU wait",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 9,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "cpu_usage_user{cpu=\"cpu-total\", host=~\"$node\"}",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU user",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 10,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "cpu_usage_system{cpu=\"cpu-total\", host=~\"$node\"}",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU system",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 11,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "cpu_usage_softirq{cpu=\"cpu-total\", host=~\"$node\"}",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU soft interrupts",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 12,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "cpu_usage_irq{cpu=\"cpu-total\", host=~\"$node\"}",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU interrupts",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 13,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "cpu_usage_nice{cpu=\"cpu-total\", host=~\"$node\"}",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU nice",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 14,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "cpu_usage_idle{cpu=\"cpu-total\", host=~\"$node\"}",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU Idle",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "CPU usage",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 15,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "mem_cached{host=~\"$node\"}",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Mem cached",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 16,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "mem_buffered{host=~\"$node\"}",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Mem buffered",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 17,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "mem_free{host=~\"$node\"}",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Mem free",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 18,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "mem_used{host=~\"$node\"}",
+                "intervalFactor": 2,
+                "legendFormat": "{{host}}",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Mem used",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "Memory usage",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 19,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "rate(diskio_reads{name=~\"$disk\", host=~\"$node\"}[5m])",
+                "intervalFactor": 2,
+                "legendFormat": "Read {{host}} {{name}}",
+                "refId": "A",
+                "step": 2
+              },
+              {
+                "expr": "rate(diskio_writes{name=~\"$disk\", host=~\"$node\"}[5m])",
+                "intervalFactor": 2,
+                "legendFormat": "Write {{host}} {{name}}",
+                "refId": "B",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Disk read/s and write/s",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 20,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "rate(diskio_read_bytes{name=~\"$disk\", host=~\"$node\"}[5m])",
+                "intervalFactor": 2,
+                "legendFormat": "Read {{host}} {{name}}",
+                "refId": "A",
+                "step": 2
+              },
+              {
+                "expr": "rate(diskio_write_bytes{name=~\"$disk\", host=~\"$node\"}[5m])",
+                "intervalFactor": 2,
+                "legendFormat": "Write {{host}} {{name}}",
+                "refId": "B",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Disk read/s and write/s",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "Disk statistics",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus - Juju generated source",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 22,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "rate(net_bytes_sent{interface=~\"$interface\", host=~\"$node\"}[5m])*8",
+                "intervalFactor": 2,
+                "legendFormat": "Out  {{host}} {{interface}}",
+                "refId": "A",
+                "step": 2
+              },
+              {
+                "expr": "rate(net_bytes_recv{interface=~\"$interface\", host=~\"$node\"}[5m])*8",
+                "intervalFactor": 2,
+                "legendFormat": "In {{host}} {{interface}}",
+                "refId": "B",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Network load",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "Network",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+      "Juju"
+    ],
+    "templating": {
+      "list": [
+        {
+          "allValue": ".*",
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "prometheus - Juju generated source",
+          "hide": 0,
+          "includeAll": true,
+          "label": null,
+          "multi": false,
+          "name": "node",
+          "options": [],
+          "query": "label_values(host)",
+          "refresh": 1,
+          "regex": "/.*(node.*).*/",
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": ".*",
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "prometheus - Juju generated source",
+          "hide": 0,
+          "includeAll": true,
+          "label": null,
+          "multi": false,
+          "name": "disk",
+          "options": [],
+          "query": "query_result(sum by (name) (diskio_read_bytes{host=\"$node\"}))",
+          "refresh": 1,
+          "regex": "/.*\"(.*)\".*/",
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": ".*",
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "prometheus - Juju generated source",
+          "hide": 0,
+          "includeAll": true,
+          "label": null,
+          "multi": false,
+          "name": "interface",
+          "options": [],
+          "query": "query_result(sum by (interface) (net_bytes_recv{host=\"$node\"}))",
+          "refresh": 1,
+          "regex": "/.*\"(.*)\".*/",
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-5m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Node Metrics (via Telegraf)",
+    "version": 4
+  },
+  "overwrite": false
+}

--- a/hadoop-spark/steps/02_monitoring/metadata.yaml
+++ b/hadoop-spark/steps/02_monitoring/metadata.yaml
@@ -1,0 +1,11 @@
+title: Monitoring Mechanism
+description: Choose the preferred monitoring mechanism
+viewable: True
+additional-input:
+  - label: Monitoring
+    key: MONITORPLUGIN
+    type: choice
+    default: Ganglia
+    choices:
+      - Ganglia
+      - Telegraf/Prometheus/Grafana

--- a/hadoop-spark/steps/02_monitoring/tpg.yaml
+++ b/hadoop-spark/steps/02_monitoring/tpg.yaml
@@ -1,0 +1,24 @@
+services:
+  grafana:
+    charm: cs:xenial/grafana-4
+    num_units: 1
+    expose: true
+    to:
+      - "4"
+  prometheus:
+    charm: cs:xenial/prometheus-5
+    num_units: 1
+    to:
+      - "5"
+  telegraf:
+    charm: cs:xenial/telegraf-6
+relations:
+  - ["prometheus:grafana-source", "grafana:grafana-source"]
+  - ["telegraf:prometheus-client", "prometheus:target"]
+  - ["namenode:juju-info", "telegraf:juju-info"]
+  - ["slave:juju-info", "telegraf:juju-info"]
+machines:
+  "4":
+    series: "xenial"
+  "5":
+    series: "xenial"

--- a/spark-processing/steps/01_logging/efg.yaml
+++ b/spark-processing/steps/01_logging/efg.yaml
@@ -30,8 +30,8 @@ relations:
   - ["apache2:reverseproxy", "graylog:website"]
   - ["graylog:elasticsearch", "elasticsearch:client"]
   - ["graylog:mongodb", "mongodb:database"]
-  - ["filebeat:beats-host", "spark:juju-info"]
-  - ["filebeat:beats-host", "zookeeper:juju-info"]
+  - ["spark:juju-info", "filebeat:beats-host"]
+  - ["zookeeper:juju-info", "filebeat:beats-host"]
 machines:
   "5":
     series: "xenial"

--- a/spark-processing/steps/01_logging/metadata.yaml
+++ b/spark-processing/steps/01_logging/metadata.yaml
@@ -1,4 +1,4 @@
-title: Choose Logging Application
+title: Logging Mechanism
 description: Choose the preferred logging mechanism
 viewable: True
 additional-input:

--- a/spark-processing/steps/02_monitoring/after-deploy
+++ b/spark-processing/steps/02_monitoring/after-deploy
@@ -5,23 +5,40 @@ set -eux
 . "$CONJURE_UP_SPELLSDIR/sdk/common.sh"
 
 if [[ "$MONITORPLUGIN" == "Ganglia" ]]; then
+    # Since Ganglia is not password-protected, the bundle does not expose it
+    # by default. Do it now since the user wants it.
+    juju expose ganglia
+
     ip=$(unitAddress ganglia)
     setResult "The Ganglia UI is available at: http://$ip/ganglia."
 elif [[ "$MONITORPLUGIN" == "Telegraf/Prometheus/Grafana" ]]; then
     # gather vars (stripping quotes) for later config and result message
     grafana_public_ip=$(unitAddress grafana)
     grafana_port=$(juju config grafana port | sed -e 's/"//g')
-    prom_ingress_ip=$(juju run --unit prometheus/0 'network-get target --format yaml --ingress-address' | head -1)
-    prom_port=$(juju config prometheus prometheus_registration_port | sed -e 's/"//g')
-    prom_token=$(juju config prometheus prometheus_registration_authtoken | sed -e 's/"//g')
 
-    juju config telegraf promreg_authtoken="$prom_token" \
-                         promreg_url="http://$prom_ingress_ip:$prom_port"
+    # setup grafana dashboards
     juju run-action --wait grafana/0 import-dashboard \
       dashboard="$(base64 $(scriptPath)/grafana-telegraf.json)"
 
     setResult "The Grafana UI is available at: http://$grafana_public_ip:$grafana_port. \
 Retrieve the admin password with 'juju run-action --wait grafana/0 get-admin-password'."
+else
+    setResult "Ignored unexpected monitoring input: $MONITORPLUGIN."
+
+    # NB: if we ever include a metric provider that doesn't support the
+    # prometheus:target relation, we may want to explore the prom_reg layer:
+    #  https://git.launchpad.net/~prometheus-registration-developers/prometheus-registration/+git/layer-promreg-client/tree/README.md
+    #  https://git.launchpad.net/~prometheus-registration-developers/prometheus-registration/tree/README.md
+    # For example, if telegraf didn't support a direct prometheus relation, we
+    # would configure it like this:
+    #
+    #prom_ingress_ip=$(juju run --unit prometheus/0 'network-get target --format yaml --ingress-address' | head -1)
+    #prom_port=$(juju config prometheus prometheus_registration_port | sed -e 's/"//g')
+    #prom_token=$(juju config prometheus prometheus_registration_authtoken | sed -e 's/"//g')
+    #
+    #juju config prometheus prometheus_registration_listen='0.0.0.0'
+    #juju config telegraf promreg_authtoken="$prom_token" \
+    #                     promreg_url="http://$prom_ingress_ip:$prom_port"
 fi
 
 exit 0

--- a/spark-processing/steps/02_monitoring/grafana-telegraf.json
+++ b/spark-processing/steps/02_monitoring/grafana-telegraf.json
@@ -1873,7 +1873,7 @@
       ]
     },
     "timezone": "browser",
-    "title": "Telegraf Node Metrics",
+    "title": "Node Metrics (via Telegraf)",
     "version": 4
   },
   "overwrite": false

--- a/spark-processing/steps/02_monitoring/metadata.yaml
+++ b/spark-processing/steps/02_monitoring/metadata.yaml
@@ -1,4 +1,4 @@
-title: Choose Monitoring Application
+title: Monitoring Mechanism
 description: Choose the preferred monitoring mechanism
 viewable: True
 additional-input:

--- a/spark-processing/steps/02_monitoring/tpg.yaml
+++ b/spark-processing/steps/02_monitoring/tpg.yaml
@@ -8,8 +8,6 @@ services:
   prometheus:
     charm: cs:xenial/prometheus-5
     num_units: 1
-    options:
-      prometheus_registration_listen: '0.0.0.0'
     to:
       - "6"
   telegraf:

--- a/spells-index.yaml
+++ b/spells-index.yaml
@@ -32,8 +32,12 @@ bigdata:
     - key: hadoop-processing
       name: Apache Hadoop Cluster
       description: |
-        Provides a complete deployment of the core Hadoop components of the Apache Bigtop platform to perform distributed data processing at scale. Ganglia and rsyslog applications are also provided to monitor cluster health and syslog activity.
+        Deploys a core Hadoop cluster with Apache Bigtop components to perform distributed data processing at scale. Monitoring and Logging options are available to monitor cluster health and application/syslog activity.
     - key: spark-processing
       name: Apache Spark Cluster
       description: |
-        Provides a complete deployment of Apache Spark in standalone HA mode as provided by Apache Bigtop. Ganglia and rsyslog applications are included to monitor cluster health and syslog activity.
+        Deploys a highly-available Spark cluster with Apache Bigtop components. Monitoring and Logging options are available to monitor cluster health and application/syslog activity.
+    - key: hadoop-spark
+      name: Apache Hadoop + Spark Cluster
+      description: |
+        Deploys a cluster with Hadoop and Spark components from Apache Bigtop to provide both batch and streaming data processing workflows. Monitoring and Logging options are available to monitor cluster health and application/syslog activity.


### PR DESCRIPTION
This re-adds the `hadoop-spark` bundle as a big data option.  It also uses the direct telegraf->prometheus relation instead of relying on the promreg layer.