### PR TITLE
Sets "None" as default if kv-cli returns no results

### DIFF
--- a/sdk/common.sh
+++ b/sdk/common.sh
@@ -312,5 +312,5 @@ setKey()
 # $1: KEY
 getKey()
 {
-    kv-cli "$KV_DB" get "conjure-up.$CONJURE_UP_SPELL.$1"
+    kv-cli "$KV_DB" get "conjure-up.$CONJURE_UP_SPELL.$1" || echo "None"
 }


### PR DESCRIPTION
This fixes the provider setup in openstack lxd where no bridges were being set
in headless mode.

This is a fix for default headless runs, more code is needed in conjure-up to
define alternative bridges/storage options for headless.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>