### PR TITLE
Support gpu workers as separate application names

### DIFF
--- a/canonical-kubernetes/steps/04_enable-cni/ec2/enable-cni
+++ b/canonical-kubernetes/steps/04_enable-cni/ec2/enable-cni
@@ -99,7 +99,7 @@ add_role_to_profile() {
 
 get_instance_ids() {
     role="$1"  # master or worker
-    instances="$(juju status -m "$JUJU_CONTROLLER:$JUJU_MODEL" "kubernetes-$role" --format=yaml | grep instance-id | awk '{print $2}')"
+    instances="$(juju status -m "$JUJU_CONTROLLER:$JUJU_MODEL" "kubernetes-$role*" --format=yaml | grep instance-id | awk '{print $2}')"
     if [[ -z "$instances" ]]; then
         abort "Unable to find kubernetes-$role instances"
     fi


### PR DESCRIPTION
We need to allow for some workers to be deployed as, e.g., `kubernetes-worker-gpu`.  Luckily, Juju supports wildcards on the application names.