### PR TITLE
Change get_instance_ids to select based on charm name

### DIFF
--- a/canonical-kubernetes/steps/04_enable-cni/ec2/enable-cni
+++ b/canonical-kubernetes/steps/04_enable-cni/ec2/enable-cni
@@ -99,7 +99,7 @@ add_role_to_profile() {
 
 get_instance_ids() {
     role="$1"  # master or worker
-    instances="$(juju status -m "$JUJU_CONTROLLER:$JUJU_MODEL" "kubernetes-$role*" --format=yaml | grep instance-id | awk '{print $2}')"
+    instances="$(juju status -m "$JUJU_CONTROLLER:$JUJU_MODEL" --format=json | jq -r ".machines as \$machines | .applications[] | select(.\"charm-name\"==\"kubernetes-$role\") | \$machines[.units[].machine].\"instance-id\"")"
     if [[ -z "$instances" ]]; then
         abort "Unable to find kubernetes-$role instances"
     fi
@@ -141,7 +141,7 @@ get_security_groups() {
                       --region "$JUJU_REGION" \
                       --instance-ids $instances \
                       --query "Reservations[0].Instances[0].SecurityGroups[*].[GroupId,GroupName]" \
-                      --output text | grep $sg_flag -E -- 'juju.{37}-[[:digit:]]+$'' | awk '{print $1}' 2>&1)"; then
+                      --output text | grep $sg_flag -E -- 'juju.{37}-[[:digit:]]+$' | awk '{print $1}' 2>&1)"; then
         abort "$group_ids"
     fi
     if [[ "$group_ids" == None ]]; then


### PR DESCRIPTION
Rather than filtering instances based on the deployed app name, which could change, filter them based on the actual charm name.

Also, remove errant single quote.