### PR TITLE
fix cdk client tool location (fixes #137)

### DIFF
--- a/canonical-kubernetes/steps/02_get-kubectl/after-deploy
+++ b/canonical-kubernetes/steps/02_get-kubectl/after-deploy
@@ -10,19 +10,24 @@ mkdir -p $HOME/bin
 juju scp -m $JUJU_CONTROLLER:$JUJU_MODEL kubernetes-master/0:config ~/.kube/config.$JUJU_MODEL
 
 if [[ $(uname -s) = "Darwin" ]]; then
-    repo=https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/
-    curl -sLO $repo/kubectl
+    KUBE_DEST="/usr/local/bin"
+    KUBE_REPO=https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64
+
+    curl -sLO $KUBE_REPO/kubectl
     chmod +x kubectl
-    mv kubectl /usr/local/bin/kubectl
-    curl -sLO $repo/kubefed
+    mv kubectl $KUBE_DEST/kubectl
+
+    curl -sLO $KUBE_REPO/kubefed
     chmod +x kubefed
-    mv kubefed /usr/local/bin/kubefed
+    mv kubefed $KUBE_DEST/kubefed
 else
+    KUBE_DEST="/snap/bin"
+
     sudo snap install kubectl --classic || true
     sudo snap install kubefed --classic || true
 fi
 
-echo "KUBECONFIG=$HOME/.kube/config.$JUJU_MODEL /snap/bin/kubectl \$@" > $HOME/bin/kubectl
+echo "KUBECONFIG=$HOME/.kube/config.$JUJU_MODEL $KUBE_DEST/kubectl \$@" > $HOME/bin/kubectl
 chmod +x $HOME/bin/kubectl
 
 setResult "The Kubernetes client utility (kubectl) is now available"


### PR DESCRIPTION
This sets an OS-dependent `$KUBE_DEST` so we point to the right kubectl location on all supported platforms.

Also remove the trailing slash on the darwin repo. Curling a double-slashed url like `.../amd64//kubectl` would give you an unknown key error:

```
$ curl -sLO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/darwin/amd64//kubectl
$ cat kubectl
<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>
```