### PR TITLE
Use extra-args config to set cloud-provider=aws

### DIFF
--- a/canonical-kubernetes/steps/04_enable-cni/ec2/enable-cni
+++ b/canonical-kubernetes/steps/04_enable-cni/ec2/enable-cni
@@ -222,21 +222,16 @@ tag_subnets() {
 }
 
 configure_k8s() {
-    role="$1"  # master or worker
-    if [[ "$role" == "master" ]]; then
-        snaps="kube-apiserver kube-controller-manager"
-    else
-        snaps="kubelet"
-    fi
-    for snap in $snaps; do
-        echo "Configuring cloud-provider for $snap"
-        result=$(juju run -m $JUJU_CONTROLLER:$JUJU_MODEL --format=yaml --application "kubernetes-$role" -- \
-                 bash -c "snap set $snap cloud-provider=aws && service snap.$snap.daemon restart" 2>&1)
-        if echo "$result" | grep -q 'ReturnCode: [^0]'; then
-            abort "$result"
-        fi
-        >&2 echo "Configured cloud-provider=aws for $snap"
-    done
+    echo "Configuring cloud-provider for kubernetes-master"
+    juju config -m $JUJU_CONTROLLER:$JUJU_MODEL kubernetes-master \
+        api-extra-args="cloud-provider=aws" \
+        controller-manager-extra-args="cloud-provider=aws"
+    >&2 echo "Configured cloud-provider for kubernetes-master"
+
+    echo "Configuring cloud-provider for kubernetes-worker"
+    juju config -m $JUJU_CONTROLLER:$JUJU_MODEL kubernetes-worker \
+        kubelet-extra-args="cloud-provider=aws"
+    >&2 echo "Configured cloud-provider for kubernetes-worker"
 }
 
 enable_cni() {
@@ -271,6 +266,5 @@ enable_cni() {
     tag_subnets worker "$cluster_tag"
 
     # enable the config in the cluster
-    configure_k8s master
-    configure_k8s worker
+    configure_k8s
 }


### PR DESCRIPTION
This changes the canonical-kubernetes AWS integration step to use the new extra-args charm configs to set cloud-provider=aws, instead of doing it manually with `snap set`.

Using charm config will allow us to observe these changes in the charms and reconfigure the services accordingly.

This is necessary since the node name changes based on the value of cloud-provider, which impacts node authorization and kube-proxy configuration. See https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/490 and https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/489.

extra-args configs are available in the stable charm channels today, so this should be safe to do.