### PR TITLE
update charm revs in cdk monitoring addons

### DIFF
--- a/canonical-kubernetes/addons/graylog/bundle.yaml
+++ b/canonical-kubernetes/addons/graylog/bundle.yaml
@@ -1,20 +1,20 @@
 services:
   apache2:
-    charm: cs:xenial/apache2-22
+    charm: cs:xenial/apache2-24
     num_units: 1
     expose: true
     options:
       enable_modules: "headers proxy_html proxy_http"
   elasticsearch:
-    charm: cs:xenial/elasticsearch-25
+    charm: cs:xenial/elasticsearch-26
     num_units: 1
   filebeat:
-    charm: cs:xenial/filebeat-10
+    charm: cs:xenial/filebeat-12
     options:
       logpath: '/var/log/*.log'
       kube_logs: True
   graylog:
-    charm: cs:xenial/graylog-11
+    charm: cs:xenial/graylog-12
     num_units: 1
   mongodb:
     charm: cs:xenial/mongodb-46

--- a/canonical-kubernetes/addons/prometheus/bundle.yaml
+++ b/canonical-kubernetes/addons/prometheus/bundle.yaml
@@ -1,6 +1,6 @@
 services:
   grafana:
-    charm: cs:xenial/grafana-5
+    charm: cs:xenial/grafana-7
     num_units: 1
     expose: true
   prometheus:


### PR DESCRIPTION
- bring er'body up to the latest stable revs
- the charms we really care about bumping are:
  - graylog-12: fixes issue where status is incorrect
  - filebeat-12: fixes custom fields; adds juju info to fields

Tested good with self-hosted AWS and JAAS using:
```
$ conjure-up --version
conjure-up 2.5.5
```