### PR TITLE
Adding KubeFlow addon

### DIFF
--- a/canonical-kubernetes/addons/kubeflow/metadata.yaml
+++ b/canonical-kubernetes/addons/kubeflow/metadata.yaml
@@ -1,0 +1,6 @@
+friendly-name: KubeFlow
+description: |
+  TensorFlow for Kubernetes
+
+  KubeFlow is a great way to run machine learning jobs inside Kubernetes.
+version: 1

--- a/canonical-kubernetes/addons/kubeflow/steps/01_install-ksonnet/after-deploy
+++ b/canonical-kubernetes/addons/kubeflow/steps/01_install-ksonnet/after-deploy
@@ -17,9 +17,6 @@ fi
 ksonnet_repo="https://github.com/ksonnet/ksonnet/releases/download/v$KS_VERSION"
 ksonnet_file="ks_${KS_VERSION}_${platform}_amd64.tar.gz"
 
-# always update the default config to the latest install
-echo "$HOME/.kube/config.$JUJU_MODEL" > "$HOME/.kube/config.conjure-up.default"
-
 work_dir="$(mktemp -d)"
 curl -fsSL -o "$work_dir/$ksonnet_file" "$ksonnet_repo/$ksonnet_file"
 tar -C "$work_dir" -zxvf "$work_dir/$ksonnet_file" 1>&2

--- a/canonical-kubernetes/addons/kubeflow/steps/01_install-ksonnet/after-deploy
+++ b/canonical-kubernetes/addons/kubeflow/steps/01_install-ksonnet/after-deploy
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -eux
+
+. "$CONJURE_UP_SPELLSDIR/sdk/common.sh"
+
+export KUBECONFIG=$HOME/.kube/config.$JUJU_MODEL
+
+PATH="$PATH:$HOME/bin"
+
+if [[ $(uname -s) = "Darwin" ]]; then
+    platform="darwin"
+else
+    platform="linux"
+fi
+
+ksonnet_repo="https://github.com/ksonnet/ksonnet/releases/download/v$KS_VERSION"
+ksonnet_file="ks_${KS_VERSION}_${platform}_amd64.tar.gz"
+
+# always update the default config to the latest install
+echo "$HOME/.kube/config.$JUJU_MODEL" > "$HOME/.kube/config.conjure-up.default"
+
+work_dir="$(mktemp -d)"
+curl -fsSL -o "$work_dir/$ksonnet_file" "$ksonnet_repo/$ksonnet_file"
+tar -C "$work_dir" -zxvf "$work_dir/$ksonnet_file" 1>&2
+mv "$work_dir/ks_${KS_VERSION}_${platform}_amd64/ks" "$HOME/bin/ks"
+
+rm -rf "$work_dir"
+
+setResult "Ksonnet installed and ready for use!"
+
+exit 0

--- a/canonical-kubernetes/addons/kubeflow/steps/01_install-ksonnet/metadata.yaml
+++ b/canonical-kubernetes/addons/kubeflow/steps/01_install-ksonnet/metadata.yaml
@@ -1,0 +1,9 @@
+title: Install Ksonnet
+description: |
+  Download and installs Ksonnet
+viewable: True
+additional-input:
+  - label: Ksonnet Version
+    key: KS_VERSION
+    type: text
+    default: 0.9.1

--- a/canonical-kubernetes/addons/kubeflow/steps/02_install-kubeflow/after-deploy
+++ b/canonical-kubernetes/addons/kubeflow/steps/02_install-kubeflow/after-deploy
@@ -7,9 +7,12 @@ set -eux
 export KUBECONFIG=$HOME/.kube/config.$JUJU_MODEL
 export GITHUB_TOKEN=$GITHUB_KEY
 
+mkdir -p $HOME/kubeflow
+cd $HOME/kubeflow
+
 kubectl create ns kubeflow
-ks init kubeflow
-cd kubeflow
+ks init kubeflow.$JUJU_MODEL
+cd kubeflow.$JUJU_MODEL
 ks env add cdk
 ks registry add kubeflow github.com/google/kubeflow/tree/master/kubeflow
 ks pkg install kubeflow/core
@@ -18,6 +21,6 @@ ks pkg install kubeflow/tf-job
 ks generate core kubeflow-core --name=kubeflow-core --namespace=kubeflow
 ks apply cdk -c kubeflow-core
 
-setResult "KubeFlow installed and ready for use!"
+setResult "KubeFlow installed and ready for use! You can find the ksonnet files in $HOME/kubeflow/kubeflow.$JUJU_MODEL"
 
 exit 0

--- a/canonical-kubernetes/addons/kubeflow/steps/02_install-kubeflow/after-deploy
+++ b/canonical-kubernetes/addons/kubeflow/steps/02_install-kubeflow/after-deploy
@@ -7,8 +7,8 @@ set -eux
 export KUBECONFIG=$HOME/.kube/config.$JUJU_MODEL
 export GITHUB_TOKEN=$GITHUB_KEY
 
-mkdir -p $HOME/kubeflow
-cd $HOME/kubeflow
+mkdir -p $HOME/.local/share/kubeflow
+cd $HOME/.local/share/kubeflow
 
 kubectl create ns kubeflow
 ks init kubeflow.$JUJU_MODEL

--- a/canonical-kubernetes/addons/kubeflow/steps/02_install-kubeflow/after-deploy
+++ b/canonical-kubernetes/addons/kubeflow/steps/02_install-kubeflow/after-deploy
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eux
+
+. "$CONJURE_UP_SPELLSDIR/sdk/common.sh"
+
+export KUBECONFIG=$HOME/.kube/config.$JUJU_MODEL
+export GITHUB_TOKEN=$GITHUB_KEY
+
+kubectl create ns kubeflow
+ks init kubeflow
+cd kubeflow
+ks env add cdk
+ks registry add kubeflow github.com/google/kubeflow/tree/master/kubeflow
+ks pkg install kubeflow/core
+ks pkg install kubeflow/tf-serving
+ks pkg install kubeflow/tf-job
+ks generate core kubeflow-core --name=kubeflow-core --namespace=kubeflow
+ks apply cdk -c kubeflow-core
+
+setResult "KubeFlow installed and ready for use!"
+
+exit 0

--- a/canonical-kubernetes/addons/kubeflow/steps/02_install-kubeflow/after-deploy
+++ b/canonical-kubernetes/addons/kubeflow/steps/02_install-kubeflow/after-deploy
@@ -21,6 +21,6 @@ ks pkg install kubeflow/tf-job
 ks generate core kubeflow-core --name=kubeflow-core --namespace=kubeflow
 ks apply cdk -c kubeflow-core
 
-setResult "KubeFlow installed and ready for use! You can find the ksonnet files in $HOME/kubeflow/kubeflow.$JUJU_MODEL"
+setResult "KubeFlow installed and ready for use! You can find the ksonnet files in $HOME/.local/share/kubeflow/kubeflow.$JUJU_MODEL"
 
 exit 0

--- a/canonical-kubernetes/addons/kubeflow/steps/02_install-kubeflow/metadata.yaml
+++ b/canonical-kubernetes/addons/kubeflow/steps/02_install-kubeflow/metadata.yaml
@@ -1,0 +1,9 @@
+title: Install KubeFlow
+description: |
+  Download and installs KubeFlow
+viewable: True
+additional-input:
+  - label: Github Access Token(https://github.com/settings/tokens)
+    key: GITHUB_KEY
+    type: text
+    default: 


### PR DESCRIPTION
Adding KubeFlow addon. My only concern is the github access token. Since ksonnet is pulling from the github api to download KubeFlow, it will hit the anonymous rate limit so we need an access token. It can have 0 permissions and still work. Can we add more directions in some way on conjure-up?