### PR TITLE
Fix permission denied error in 02_get-kubectl after-deploy

### DIFF
--- a/canonical-kubernetes/steps/02_get-kubectl/after-deploy
+++ b/canonical-kubernetes/steps/02_get-kubectl/after-deploy
@@ -16,7 +16,9 @@ if [[ $(uname -s) = "Darwin" ]]; then
 else
     KUBE_DEST="/snap/bin"
 
-    sudo snap install kubectl --classic || true
+    if [[ ! -e "$KUBE_DEST/kubectl" ]]; then
+        sudo snap install kubectl --classic
+    fi
 fi
 
 # copy down config file from cluster

--- a/canonical-kubernetes/steps/02_get-kubectl/after-deploy
+++ b/canonical-kubernetes/steps/02_get-kubectl/after-deploy
@@ -25,14 +25,12 @@ juju scp -m "$JUJU_CONTROLLER:$JUJU_MODEL" kubernetes-master/0:config "$HOME/.ku
 # change cluster, context, and name of user to model name
 "$(dirname "$0")/update_kube_config.py" "$HOME/.kube/config.conjure-up.$JUJU_MODEL" "$JUJU_MODEL"
 
+PREVCONFIG=""
 # clean up wrapper from any previously CDK clusters
 if [[ -e "$HOME/bin/kubectl" ]]; then
     PREVCONFIG="$(grep -o 'KUBECONFIG=[^ ]*' "$HOME/bin/kubectl")"
     rm "$HOME/bin/kubectl"
 fi
-
-# merge with any existing config and dump to config.conjure-up.new
-KUBECONFIG="$HOME/.kube/config.conjure-up.$JUJU_MODEL:$PREVCONFIG:$HOME/.kube/config" "$KUBE_DEST/kubectl" config view --raw=true > "$HOME/.kube/config.conjure-up.new"
 
 # manage backup if existing config
 if [[ -e "$HOME/.kube/config" ]]; then
@@ -44,8 +42,11 @@ if [[ -e "$HOME/.kube/config" ]]; then
     done
 fi
 
-# replace any existing config with merged, and make default
-mv "$HOME/.kube/config.conjure-up.new" "$HOME/.kube/config"
+# merge with and replace any existing config
+KUBECONFIG="$HOME/.kube/config.conjure-up.$JUJU_MODEL:$PREVCONFIG:$HOME/.kube/config"
+export KUBECONFIG
+NEW_CONFIG="$("$KUBE_DEST/kubectl" config view --raw=true)"
+echo "$NEW_CONFIG" > "$HOME/.kube/config"
 
 # clean up the copy of cluster-only config
 rm "$HOME/.kube/config.conjure-up.$JUJU_MODEL"


### PR DESCRIPTION
It seems there's an odd issue with redirecting output from a snap directly to a file in a dot-dir, even when that snap is classic and can otherwise access that file.

Fixes #176