### PR TITLE
Fix helm

### DIFF
--- a/canonical-kubernetes/addons/common.sh
+++ b/canonical-kubernetes/addons/common.sh
@@ -23,6 +23,7 @@ function install_helm() {
         work_dir="$(mktemp -d)"
 
         rm -f "$HOME/bin/helm" "$HOME/bin/.helm"  # clear potentially different version
+        mkdir -p "$HOME/bin"
 
         echo "Installing Helm CLI"
         curl -fsSL -o "$work_dir/$helm_file" "$helm_repo/$helm_file"

--- a/canonical-kubernetes/addons/common.sh
+++ b/canonical-kubernetes/addons/common.sh
@@ -15,9 +15,6 @@ function install_helm() {
     helm_repo="https://storage.googleapis.com/kubernetes-helm"
     helm_file="helm-$HELM_VERSION-$platform-amd64.tar.gz"
 
-    # always update the default config to the latest install
-    echo "$HOME/.kube/config.$JUJU_MODEL" > "$HOME/.kube/config.conjure-up.default"
-
     # only install and init Helm once per deployment
     if [[ "$(getKey "helm.installed.$CONJURE_UP_SESSION_ID")" != "true" ]]; then
         work_dir="$(mktemp -d)"
@@ -28,10 +25,7 @@ function install_helm() {
         echo "Installing Helm CLI"
         curl -fsSL -o "$work_dir/$helm_file" "$helm_repo/$helm_file"
         tar -C "$work_dir" -zxvf "$work_dir/$helm_file" 1>&2
-        mv "$work_dir/$platform-amd64/helm" "$HOME/bin/.helm"
-        chmod +x "$HOME/bin/.helm"
-        cp "$CONJURE_UP_SPELLSDIR/$CONJURE_UP_SPELL/addons/helm/helm-wrapper.sh" "$HOME/bin/helm"
-        chmod +x "$HOME/bin/helm"
+        mv "$work_dir/$platform-amd64/helm" "$HOME/bin/helm"
 
         echo "Deploying and initializing Helm"
         init_count=1

--- a/canonical-kubernetes/addons/helm/helm-wrapper.sh
+++ b/canonical-kubernetes/addons/helm/helm-wrapper.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-export KUBECONFIG="${KUBECONFIG:-$(cat "$HOME/.kube/config.conjure-up.default")}"
-"$HOME/bin/.helm" "$@"

--- a/canonical-kubernetes/addons/helm/steps/01_install-helm/after-deploy
+++ b/canonical-kubernetes/addons/helm/steps/01_install-helm/after-deploy
@@ -5,8 +5,6 @@ set -eux
 . "$CONJURE_UP_SPELLSDIR/sdk/common.sh"
 . "$CONJURE_UP_SPELLSDIR/$CONJURE_UP_SPELL/addons/common.sh"
 
-export KUBECONFIG=$HOME/.kube/config.$JUJU_MODEL
-
 install_helm
 
 setResult "Helm installed and ready for use! Be sure to checkout https://helm.sh"


### PR DESCRIPTION
Fixing two issues:

---

### Helm addon fails when the user does not have a `~/bin` folder
```
mv: cannot move '/tmp/tmp.5gLDeDUCrA/linux-amd64/helm' to '/home/gkk/bin/.helm': No such file or directory
```
Fixed this by adding `mkdir -p "$HOME/bin"` to `install_helm`.

---

### Helm addon fails during `helm init --upgrade`
```
+ helm init --upgrade
Error: error installing: Post http://localhost:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments: dial tcp 127.0.0.1:8080: getsockopt: connection refused
```
This occurs for two reasons:
1. A helm wrapper is created that points to a non-existent kubeconfig
2. The `01_install-helm` step exports `KUBECONFIG` that points to a non-existent kubeconfig

Fixed this by removing the helm wrapper and the export.