### PR TITLE
Only allow nvidia enablement on ec2

### DIFF
--- a/canonical-kubernetes-nvidia/metadata.yaml
+++ b/canonical-kubernetes-nvidia/metadata.yaml
@@ -1,6 +1,8 @@
 friendly-name: Canonical Distribution of Kubernetes with nVidia GPU workers
 version: 1
 bundle-name: ~containers/canonical-kubernetes-nvidia
+cloud-whitelist:
+- ec2
 options-whitelist:
   kubernetes-worker:
     - allow-privileged


### PR DESCRIPTION
We only want to use ec2 for gpu enabled instances (and gce when that's ready)

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>