### PR TITLE
artifactory_rel_name

### DIFF
--- a/canonical-kubernetes/addons/jfrog/steps/01_install_arti/after-deploy
+++ b/canonical-kubernetes/addons/jfrog/steps/01_install_arti/after-deploy
@@ -23,7 +23,6 @@ else
 
 fi
 
-
 # Refine the re-install_helm() and the waiting for tiller code
 # and move later to common.sh and invoke them here.
 
@@ -116,16 +115,16 @@ fi
 if [[ "$USE_INGRESS_CONTROLLER" != "true" ]]; then
     echo "Installing artifactory with nginx enabled .."
     if [[ "$SECRETSET" != "true" ]]; then
-        helm install --name art-ha-preview -f $(scriptPath)/values.yaml --set postgresql.postgresUser="$DBUSER",postgresql.postgresPassword="$DBPASS",nginx.service.type="$SERVICE_TYPE"  "$ARTIFACTORY_RELEASE" >> $INSTALLER_LOG 2>&1
+        helm install --name $ARTIFACTORY_NAME -f $(scriptPath)/values.yaml --set postgresql.postgresUser="$DBUSER",postgresql.postgresPassword="$DBPASS",nginx.service.type="$SERVICE_TYPE"  "$ARTIFACTORY_RELEASE" >> $INSTALLER_LOG 2>&1
     else
-        helm install --name art-ha-preview -f $(scriptPath)/values.yaml --set postgresql.postgresUser="$DBUSER",postgresql.postgresPassword="$DBPASS",nginx.service.type="$SERVICE_TYPE",nginx.tlsSecretName="$TLS_SECRET_NAME"  "$ARTIFACTORY_RELEASE" >> $INSTALLER_LOG 2>&1
+        helm install --name $ARTIFACTORY_NAME -f $(scriptPath)/values.yaml --set postgresql.postgresUser="$DBUSER",postgresql.postgresPassword="$DBPASS",nginx.service.type="$SERVICE_TYPE",nginx.tlsSecretName="$TLS_SECRET_NAME"  "$ARTIFACTORY_RELEASE" >> $INSTALLER_LOG 2>&1
     fi
 else
 
     echo "Installing artifactory ingress enabled and nginx disabled "
 
     if [[ "$SECRETSET" != "true" ]]; then
-        helm install --name art-ha-preview -f $(scriptPath)/values.yaml --set postgresql.postgresUser="$DBUSER",postgresql.postgresPassword="$DBPASS",ingress.enabled=true,nginx.enabled=false,artifactory.service.type="$SERVICE_TYPE" "$ARTIFACTORY_RELEASE"  >> $INSTALLER_LOG 2>&1
+        helm install --name $ARTIFACTORY_NAME -f $(scriptPath)/values.yaml --set postgresql.postgresUser="$DBUSER",postgresql.postgresPassword="$DBPASS",ingress.enabled=true,nginx.enabled=false,artifactory.service.type="$SERVICE_TYPE" "$ARTIFACTORY_RELEASE"  >> $INSTALLER_LOG 2>&1
 
     else
         echo "Generating gen_ing_tls_values.yaml from ing_tls_values.yaml ..."
@@ -138,7 +137,7 @@ else
         cat $(scriptPath)/gen_ing_tls_values.yaml
         echo "-----"
 
-        helm install --name art-ha-preview -f $(scriptPath)/values.yaml -f $(scriptPath)/gen_ing_tls_values.yaml --set postgresql.postgresUser="$DBUSER",postgresql.postgresPassword="$DBPASS",ingress.enabled=true,nginx.enabled=false,artifactory.service.type="$SERVICE_TYPE" "$ARTIFACTORY_RELEASE"  >> $INSTALLER_LOG 2>&1
+        helm install --name $ARTIFACTORY_NAME -f $(scriptPath)/values.yaml -f $(scriptPath)/gen_ing_tls_values.yaml --set postgresql.postgresUser="$DBUSER",postgresql.postgresPassword="$DBPASS",ingress.enabled=true,nginx.enabled=false,artifactory.service.type="$SERVICE_TYPE" "$ARTIFACTORY_RELEASE"  >> $INSTALLER_LOG 2>&1
     fi
 fi
 

--- a/canonical-kubernetes/addons/jfrog/steps/01_install_arti/before-config
+++ b/canonical-kubernetes/addons/jfrog/steps/01_install_arti/before-config
@@ -4,4 +4,10 @@ set -eux
 
 . "$CONJURE_UP_SPELLSDIR/sdk/common.sh"
 
+art_length=${#ARTIFACTORY_NAME}
+if [ $art_length -gt 14 ]; then
+    echo "$ARTIFACTORY_NAME length is $art_length. It should not exceed 14 characters"
+    exit 1;
+fi
+
 setStepKey "bundle-add" "channels.yaml"

--- a/canonical-kubernetes/addons/jfrog/steps/01_install_arti/metadata.yaml
+++ b/canonical-kubernetes/addons/jfrog/steps/01_install_arti/metadata.yaml
@@ -4,6 +4,10 @@ description: |
   using Helm
 viewable: True
 additional-input:
+  - label: Artifactory Release Name (Maximum 14 characters)
+    key: ARTIFACTORY_NAME
+    type: text
+    default: art-ha-preview
   - label: Database User Name
     key: DBUSER
     type: text
@@ -24,7 +28,7 @@ additional-input:
     key: SERVICE_TYPE
     type: text
     default: LoadBalancer
-  - label: Artifactory Release Name/Path
+  - label: Artifactory Release Path
     key: ARTIFACTORY_RELEASE
     type: text
     default: stable/artifactory-ha


### PR DESCRIPTION
The artifactory release name is now based on user input. The length of the name is limited to 
14 characters now and enforced in before-config so it is caught early. If the text specification
in additional-input section can take max length to limit in the gui, that would be preferable.