### PR TITLE
update cdk monitoring stack

### DIFF
--- a/canonical-kubernetes/addons/graylog/bundle.yaml
+++ b/canonical-kubernetes/addons/graylog/bundle.yaml
@@ -6,18 +6,20 @@ services:
     options:
       enable_modules: "headers proxy_html proxy_http"
   elasticsearch:
-    charm: cs:xenial/elasticsearch-26
+    charm: cs:xenial/elasticsearch-27
+    constraints: mem=3G root-disk=16G
     num_units: 1
   filebeat:
-    charm: cs:xenial/filebeat-12
+    charm: cs:~filebeat-charmers/filebeat-9
     options:
       logpath: '/var/log/*.log'
       kube_logs: True
   graylog:
-    charm: cs:xenial/graylog-12
+    charm: cs:xenial/graylog-15
+    constraints: mem=3G
     num_units: 1
   mongodb:
-    charm: cs:xenial/mongodb-46
+    charm: cs:xenial/mongodb-47
     num_units: 1
 relations:
   - ["apache2:reverseproxy", "graylog:website"]

--- a/canonical-kubernetes/addons/prometheus/bundle.yaml
+++ b/canonical-kubernetes/addons/prometheus/bundle.yaml
@@ -1,13 +1,15 @@
 services:
   grafana:
-    charm: cs:xenial/grafana-7
+    charm: cs:xenial/grafana-11
+    constraints: mem=3G
     num_units: 1
     expose: true
   prometheus:
-    charm: cs:xenial/prometheus-5
+    charm: cs:xenial/prometheus-6
+    constraints: mem=3G root-disk=16G
     num_units: 1
   telegraf:
-    charm: cs:xenial/telegraf-9
+    charm: cs:xenial/telegraf-13
 relations:
   - ["prometheus:grafana-source", "grafana:grafana-source"]
   - ["telegraf:prometheus-client", "prometheus:target"]

--- a/canonical-kubernetes/addons/prometheus/steps/01_install-prometheus/after-deploy
+++ b/canonical-kubernetes/addons/prometheus/steps/01_install-prometheus/after-deploy
@@ -27,8 +27,10 @@ juju config -m "$JUJU_CONTROLLER:$JUJU_MODEL" prometheus \
   scrape-jobs="$(sed -e s/K8S_PASSWORD/$kube_client_pass/g -e s/K8S_API_ENDPOINT/$kube_ingress_ip/g $(scriptPath)/prometheus-scrape-k8s.yaml)"
 
 # setup grafana dashboards
-juju run-action -m "$JUJU_CONTROLLER:$JUJU_MODEL" --wait grafana/0 \
-  import-dashboard dashboard="$(base64 $(scriptPath)/grafana-telegraf.json)"
+# NB: recent telegraf charm includes a nice dashboard by default; comment out
+# the telegraf dashboard included in this step for now (deprecate/remove later)
+#juju run-action -m "$JUJU_CONTROLLER:$JUJU_MODEL" --wait grafana/0 \
+#  import-dashboard dashboard="$(base64 $(scriptPath)/grafana-telegraf.json)"
 juju run-action -m "$JUJU_CONTROLLER:$JUJU_MODEL" --wait grafana/0 \
   import-dashboard dashboard="$(base64 $(scriptPath)/grafana-k8s.json)"
 


### PR DESCRIPTION
- bump charm revs to latest from the charm store
- add constraints for monitoring stack
- deprecate telegraf dashboard
  - the latest telegraf gives us a nice dashboard, so stop importing the
    custom one from the cdk step. leave it around in case anyone happens to
    like it better, but if no one notices we've stopped using it, we can
    remove it.