### PR TITLE
Use new integrator charm names

### DIFF
--- a/canonical-kubernetes/steps/04_enable-cni/ec2/enable-cni
+++ b/canonical-kubernetes/steps/04_enable-cni/ec2/enable-cni
@@ -7,9 +7,9 @@ get_creds() {
 }
 
 enable_cni() {
-    if ! juju trust -m "$JUJU_CONTROLLER:$JUJU_MODEL" aws; then
+    if ! juju trust -m "$JUJU_CONTROLLER:$JUJU_MODEL" aws-integrator; then
         >&2 echo "juju-trust not available; falling back to passing credentials via charm config."
         >&2 echo "Note: Charm config can be read by anyone with read access to the model."
-        juju config -m "$JUJU_CONTROLLER:$JUJU_MODEL" aws credentials="$(get_creds)"
+        juju config -m "$JUJU_CONTROLLER:$JUJU_MODEL" aws-integrator credentials="$(get_creds)"
     fi
 }

--- a/canonical-kubernetes/steps/04_enable-cni/ec2/overlay.yaml
+++ b/canonical-kubernetes/steps/04_enable-cni/ec2/overlay.yaml
@@ -1,7 +1,7 @@
 applications:
-  aws:
-    charm: cs:~containers/aws
+  aws-integrator:
+    charm: cs:~containers/aws-integrator
     num_units: 1
 relations:
-  - ['aws', 'kubernetes-master']
-  - ['aws', 'kubernetes-worker']
+  - ['aws-integrator', 'kubernetes-master']
+  - ['aws-integrator', 'kubernetes-worker']

--- a/canonical-kubernetes/steps/04_enable-cni/gce/enable-cni
+++ b/canonical-kubernetes/steps/04_enable-cni/gce/enable-cni
@@ -8,9 +8,9 @@ get_creds() {
 }
 
 enable_cni() {
-    if ! juju trust -m "$JUJU_CONTROLLER:$JUJU_MODEL" gcp; then
+    if ! juju trust -m "$JUJU_CONTROLLER:$JUJU_MODEL" gcp-integrator; then
         >&2 echo "juju-trust not available; falling back to passing credentials via charm config."
         >&2 echo "Note: Charm config can be read by anyone with read access to the model."
-        juju config -m "$JUJU_CONTROLLER:$JUJU_MODEL" gcp credentials="$(get_creds)"
+        juju config -m "$JUJU_CONTROLLER:$JUJU_MODEL" gcp-integrator credentials="$(get_creds)"
     fi
 }

--- a/canonical-kubernetes/steps/04_enable-cni/gce/overlay.yaml
+++ b/canonical-kubernetes/steps/04_enable-cni/gce/overlay.yaml
@@ -1,7 +1,7 @@
 applications:
-  gcp:
-    charm: cs:~containers/gcp
+  gcp-integrator:
+    charm: cs:~containers/gcp-integrator
     num_units: 1
 relations:
-  - ['gcp', 'kubernetes-master']
-  - ['gcp', 'kubernetes-worker']
+  - ['gcp-integrator', 'kubernetes-master']
+  - ['gcp-integrator', 'kubernetes-worker']


### PR DESCRIPTION
The charm and interface names for the integrator charms were updated to remove ambiguity.  The support for these changes was released in the Kubernetes charms and the spell needs this update to continue to work.