### PR TITLE
verify our kubectl download on macos

### DIFF
--- a/canonical-kubernetes/steps/02_get-kubectl/after-deploy
+++ b/canonical-kubernetes/steps/02_get-kubectl/after-deploy
@@ -11,6 +11,11 @@ if [[ $(uname -s) = "Darwin" ]]; then
     KUBE_REPO=https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64
 
     curl -sLO "$KUBE_REPO/kubectl"
+    if ! file kubectl 2>&1 | grep -qi 'executable'; then
+        echo "Failed to download a valid kubectl binary from $KUBE_REPO/kubectl"
+        setResult "kubectl is not a valid binary"
+        exit 1
+    fi
     chmod +x kubectl
     mv kubectl "$KUBE_DEST/kubectl"
 else


### PR DESCRIPTION
This is related to #187 -- it doesn't fix the timeout, but it will at least stop the deployment with a helpful message if we curl'd an invalid binary on macos.

@battlemidget i'm not sure if `exit 1` is the right thing to do here.  I think it is because subsequent steps will try to use `kubectl`, so i think we want to bail as soon as we know that's not gonna work.