### PR TITLE
[WIP] get service and pod metrics via our prometheus scraper

### DIFF
--- a/canonical-kubernetes/addons/prometheus/steps/01_install-prometheus/prometheus-scrape-k8s.yaml
+++ b/canonical-kubernetes/addons/prometheus/steps/01_install-prometheus/prometheus-scrape-k8s.yaml
@@ -1,4 +1,21 @@
-- job_name: 'k8s-api-endpoints'
+# A scrape configuration for running Prometheus on a Kubernetes cluster.
+# This uses separate scrape configs for cluster components (i.e. API server, node)
+# and services to allow each to use different authentication configs.
+#
+# Kubernetes labels will be added as Prometheus labels on metrics via the
+# `labelmap` relabeling action.
+#
+# If you are using Kubernetes 1.7.2 or earlier, please take note of the comments
+# for the kubernetes-cadvisor job; you will need to edit or remove this job.
+
+# Scrape config for API servers.
+#
+# Kubernetes exposes API servers as endpoints to the default/kubernetes
+# service so this uses `endpoints` role and uses relabelling to only keep
+# the endpoints associated with the default/kubernetes service using the
+# default named port `https`. This works for single API server deployments as
+# well as HA API server deployments.
+- job_name: 'kubernetes-apiservers'
   kubernetes_sd_configs:
   - api_server: K8S_API_ENDPOINT
     role: endpoints
@@ -18,6 +35,13 @@
   - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
     action: keep
     regex: default;kubernetes;https
+
+# Scrape config for nodes (kubelet).
+#
+# Rather than connecting directly to the node, the scrape is proxied though the
+# Kubernetes apiserver.  This means it will work if Prometheus is running out of
+# cluster, or can't connect to nodes for some other reason (e.g. because of
+# firewalling).
 - job_name: 'kubernetes-nodes'
   kubernetes_sd_configs:
   - api_server: K8S_API_ENDPOINT
@@ -43,6 +67,21 @@
     regex: (.+)
     target_label: __metrics_path__
     replacement: /api/v1/nodes/$1/proxy/metrics
+
+# Scrape config for Kubelet cAdvisor.
+#
+# This is required for Kubernetes 1.7.3 and later, where cAdvisor metrics
+# (those whose names begin with 'container_') have been removed from the
+# Kubelet metrics endpoint.  This job scrapes the cAdvisor endpoint to
+# retrieve those metrics.
+#
+# In Kubernetes 1.7.0-1.7.2, these metrics are only exposed on the cAdvisor
+# HTTP endpoint; use "replacement: /api/v1/nodes/${1}:4194/proxy/metrics"
+# in that case (and ensure cAdvisor's HTTP server hasn't been disabled with
+# the --cadvisor-port=0 Kubelet flag).
+#
+# This job is not necessary and should be removed in Kubernetes 1.6 and
+# earlier versions, or it will cause the metrics to be scraped twice.
 - job_name: 'kubernetes-cadvisor'
   kubernetes_sd_configs:
   - api_server: K8S_API_ENDPOINT
@@ -68,3 +107,104 @@
     regex: (.+)
     target_label: __metrics_path__
     replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+
+# Example scrape config for service endpoints.
+#
+# The relabeling allows the actual service scrape endpoint to be configured
+# for all or only some endpoints.
+- job_name: 'kubernetes-service-endpoints'
+  kubernetes_sd_configs:
+  - role: endpoints
+    api_server: K8S_API_ENDPOINT
+    tls_config:
+      insecure_skip_verify: true
+    basic_auth:
+      username: admin
+      password: K8S_PASSWORD
+  scheme: https
+  scrape_interval: 30s
+  tls_config:
+    insecure_skip_verify: true
+  basic_auth:
+    username: admin
+    password: K8S_PASSWORD
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+    action: keep
+    regex: true
+  - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
+    action: replace
+    regex: (\d+)
+    target_label: __meta_kubernetes_pod_container_port_number
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    action: replace
+    regex: ()
+    target_label: __meta_kubernetes_service_annotation_prometheus_io_path
+    replacement: /metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_pod_container_port_number, __meta_kubernetes_service_annotation_prometheus_io_path]
+    target_label: __metrics_path__
+    regex: (.+);(.+);(.+);(.+)
+    replacement: /api/v1/namespaces/$1/services/$2:$3/proxy$4
+  - target_label: __address__
+    replacement: K8S_API_ENDPOINT:443
+  - action: labelmap
+    regex: __meta_kubernetes_service_label_(.+)
+  - source_labels: [__meta_kubernetes_namespace]
+    action: replace
+    target_label: kubernetes_namespace
+  - source_labels: [__meta_kubernetes_service_name]
+    action: replace
+    target_label: kubernetes_name
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    action: replace
+    target_label: instance
+
+
+
+# Example scrape config for pods
+#
+# The relabeling allows the actual pod scrape to be configured
+# for all the declared ports (or port-free target if none is declared)
+# or only some ports.
+- job_name: 'kubernetes-pods'
+  kubernetes_sd_configs:
+  - role: pod
+    api_server: K8S_API_ENDPOINT
+    tls_config:
+      insecure_skip_verify: true
+    basic_auth:
+      username: admin
+      password: K8S_PASSWORD
+  scheme: https
+  scrape_interval: 30s
+  tls_config:
+    insecure_skip_verify: true
+  basic_auth:
+    username: admin
+    password: K8S_PASSWORD
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+    action: keep
+    regex: true
+  - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+    action: replace
+    regex: ()
+    target_label: __meta_kubernetes_pod_annotation_prometheus_io_path
+    replacement: /metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __meta_kubernetes_pod_container_port_number, __meta_kubernetes_pod_annotation_prometheus_io_path]
+    target_label: __metrics_path__
+    regex: (.+);(.+);(.+);(.+)
+    replacement: /api/v1/namespaces/$1/pods/$2:$3/proxy$4
+  - target_label: __address__
+    replacement: K8S_API_ENDPOINT:443
+  - action: labelmap
+    regex: __meta_kubernetes_pod_label_(.+)
+  - source_labels: [__meta_kubernetes_namespace]
+    action: replace
+    target_label: kubernetes_namespace
+  - source_labels: [__meta_kubernetes_pod_name]
+    action: replace
+    target_label: kubernetes_pod_name
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    action: replace
+    target_label: instance


### PR DESCRIPTION
This isn't quite ready yet, but it brings in the latest service and pod metrics functionality from the upstream prometheus scraper:

https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml

Since our prometheus is not `in-cluster`, we have to get svc/pod metrics via the load balancer.  I lifted relabeling configs to do this from the following gist:

https://gist.github.com/sacreman/b61266d2ec52cf3a1af7c278d9d93450

It's still not quite right though:

![screen shot 2018-07-12 at 4 27 42 pm](https://user-images.githubusercontent.com/4576822/42662963-34eacd22-85f9-11e8-9118-85d287ddd521.png)

As an example into the red, see what prometheus is effectively trying to do for the `nginx-ingress` pod:
```
$ curl -u admin:PASSWORD -k https://KUBEAPI_LOAD_BALANCER:443/api/v1/namespaces/default/pods/nginx-ingress-kubernetes-worker-controller-jp962:443/proxy/metrics
<html>
<head><title>400 The plain HTTP request was sent to HTTPS port</title></head>
<body bgcolor="white">
<center><h1>400 Bad Request</h1></center>
<center>The plain HTTP request was sent to HTTPS port</center>
<hr><center>nginx/1.13.12</center>
</body>
</html>
```

You might say, "oh hey, just stop trying to hit pod:443 and you'll get past this".  I'd be like, "OK", and then show you this:
```
$ curl -u admin:bm0fGt3hFNudiYc8GYbCIg8KsEURSME3 -k https://172.31.23.115:443/api/v1/namespaces/default/pods/nginx-ingress-kubernetes-worker-controller-jp962/proxy/metrics
<html>
<head><title>502 Bad Gateway</title></head>
<body bgcolor="white">
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx/1.13.12</center>
</body>
</html>
```

We do have some green, which makes me think we're on the right track.  It could be some of these things are not producing metrics, or we're looking for them in the wrong place (maybe not proxied how we expect).  I wanted to put this up to solicit ideas from anyone who may know how to scrape pods/services from a prometheus that is not `in-cluster`.

NOTE: to even get what we have now, we have to annotate pods and services so that the scraper sees them from the api server:
```
kubectl annotate pod --namespace='[default|kube-system]' --all prometheus.io/scrape=true
kubectl annotate svc --namespace='[default|kube-system]' --all prometheus.io/scrape=true
```