### PR TITLE
update the monitoring stack for cdk

### DIFF
--- a/canonical-kubernetes/addons/graylog/bundle.yaml
+++ b/canonical-kubernetes/addons/graylog/bundle.yaml
@@ -1,26 +1,28 @@
 services:
   apache2:
-    charm: cs:xenial/apache2-24
+    charm: cs:bionic/apache2-26
     num_units: 1
     expose: true
     options:
       enable_modules: "headers proxy_html proxy_http"
   elasticsearch:
-    charm: cs:xenial/elasticsearch-27
+    charm: cs:bionic/elasticsearch-29
     constraints: mem=3G root-disk=16G
     num_units: 1
   filebeat:
-    charm: cs:~filebeat-charmers/filebeat-9
+    charm: cs:xenial/filebeat-19
     options:
       logpath: '/var/log/*.log'
       kube_logs: True
   graylog:
-    charm: cs:xenial/graylog-15
+    charm: cs:bionic/graylog-19
     constraints: mem=3G
     num_units: 1
   mongodb:
-    charm: cs:xenial/mongodb-47
+    charm: cs:bionic/mongodb-49
     num_units: 1
+    options:
+      extra_daemon_options: "--bind_ip_all"
 relations:
   - ["apache2:reverseproxy", "graylog:website"]
   - ["graylog:elasticsearch", "elasticsearch:client"]

--- a/canonical-kubernetes/addons/prometheus/bundle.yaml
+++ b/canonical-kubernetes/addons/prometheus/bundle.yaml
@@ -1,15 +1,15 @@
 services:
   grafana:
-    charm: cs:xenial/grafana-11
+    charm: cs:bionic/grafana-17
     constraints: mem=3G
     num_units: 1
     expose: true
   prometheus:
-    charm: cs:xenial/prometheus-6
+    charm: cs:xenial/prometheus-7
     constraints: mem=3G root-disk=16G
     num_units: 1
   telegraf:
-    charm: cs:xenial/telegraf-13
+    charm: cs:xenial/telegraf-16
 relations:
   - ["prometheus:grafana-source", "grafana:grafana-source"]
   - ["telegraf:prometheus-client", "prometheus:target"]

--- a/canonical-kubernetes/addons/prometheus/steps/01_install-prometheus/after-deploy
+++ b/canonical-kubernetes/addons/prometheus/steps/01_install-prometheus/after-deploy
@@ -27,12 +27,14 @@ juju config -m "$JUJU_CONTROLLER:$JUJU_MODEL" prometheus \
   scrape-jobs="$(sed -e s/K8S_PASSWORD/$kube_client_pass/g -e s/K8S_API_ENDPOINT/$kube_ingress_ip/g $(scriptPath)/prometheus-scrape-k8s.yaml)"
 
 # setup grafana dashboards
-# NB: recent telegraf charm includes a nice dashboard by default; comment out
-# the telegraf dashboard included in this step for now (deprecate/remove later)
-#juju run-action -m "$JUJU_CONTROLLER:$JUJU_MODEL" --wait grafana/0 \
-#  import-dashboard dashboard="$(base64 $(scriptPath)/grafana-telegraf.json)"
 juju run-action -m "$JUJU_CONTROLLER:$JUJU_MODEL" --wait grafana/0 \
   import-dashboard dashboard="$(base64 $(scriptPath)/grafana-k8s.json)"
+# NB: recent grafana charm includes a nice telegraf dashboard by default;
+# however, if not all metrics are available, the dashboard will not load:
+#   Skipping Dashboard Template: Telegraf.json.j2 no metric net_link_mtu
+# Import a known good dashboard so users at least have something to build on.
+juju run-action -m "$JUJU_CONTROLLER:$JUJU_MODEL" --wait grafana/0 \
+  import-dashboard dashboard="$(base64 $(scriptPath)/grafana-telegraf.json)"
 
 setResult "The Grafana UI is available at: http://$grafana_public_ip:$grafana_port. \
 Retrieve the admin password with 'juju run-action --wait grafana/0 get-admin-password'."


### PR DESCRIPTION
- bump charm revs
- use bionic if possible
  - cant do it for subordinates yet because k8s principals are xenial
- add the telegraf dashboard back
  - recent grafana update wont load a dashboard if a metric is missing, which is the case for the default grafana/Telegraf2.json dash. Use a known good dashboard so users have something to build off of:
  https://code.launchpad.net/~chris.sanders/grafana-charm/+git/grafana-charm/+merge/348122

Tested well with conjure-up 2.6.0 on Darwin and AWS.