### PR TITLE
use_latest_kub

### DIFF
--- a/canonical-kubernetes/addons/jfrog/steps/01_install_arti/before-config
+++ b/canonical-kubernetes/addons/jfrog/steps/01_install_arti/before-config
@@ -10,4 +10,4 @@ if [ $art_length -gt 14 ]; then
     exit 1;
 fi
 
-setStepKey "bundle-add" "channels.yaml"
+

--- a/canonical-kubernetes/addons/jfrog/steps/01_install_arti/values.yaml
+++ b/canonical-kubernetes/addons/jfrog/steps/01_install_arti/values.yaml
@@ -10,6 +10,18 @@ initContainerImage: "alpine:3.6"
 # For supporting pulling from private registries
 imagePullSecrets:
 
+## Role Based Access Control
+## Ref: https://kubernetes.io/docs/admin/authorization/rbac/
+rbac:
+  create: false
+
+## Service Account
+## Ref: https://kubernetes.io/docs/admin/service-accounts-admin/
+##
+serviceAccount:
+  create: false
+
+
 # Artifactory
 artifactory:
   persistence:


### PR DESCRIPTION
Remove restriction of 1.9 snaps of kubernetes to nake use of all new features of latest versions 
of kubernetes. Also ensure rbac is disabled for now.