### PR TITLE
Using the new JFrog's offical helm repo https://charts.jfrog.io

### DIFF
--- a/canonical-kubernetes/addons/jfrog/steps/01_install_arti/after-deploy
+++ b/canonical-kubernetes/addons/jfrog/steps/01_install_arti/after-deploy
@@ -52,9 +52,9 @@ echo "Ensure Tiller is deployed and available ..."
 $KUBECTL -n kube-system get deployment tiller-deploy -w
 
 
-echo "Helm upgrade and Tiller deployed. Now add repo stable "
+echo "Helm upgrade and Tiller deployed. Now add repo jfrog "
 
-$HOME/bin/helm repo add stable https://kubernetes-charts.storage.googleapis.com
+$HOME/bin/helm repo add jfrog https://charts.jfrog.io/
 echo "Helm Repo added. Now to artifactory .."
 
 # Issue in persistence storage class/volume/zone/node

--- a/canonical-kubernetes/addons/jfrog/steps/01_install_arti/metadata.yaml
+++ b/canonical-kubernetes/addons/jfrog/steps/01_install_arti/metadata.yaml
@@ -31,7 +31,7 @@ additional-input:
   - label: Artifactory Release Path
     key: ARTIFACTORY_RELEASE
     type: text
-    default: stable/artifactory-ha
+    default: jfrog/artifactory-ha
   - label: Configure TLS with user cert and key file
     key: CONFIG_TLS_SECRET
     type: text


### PR DESCRIPTION
JFrog's offical helm repo is now available at https://charts.jfrog.io
Please see https://github.com/jfrog/charts for more information.