### PR TITLE
support vsphere-integrator in cdk

### DIFF
--- a/canonical-kubernetes/steps/04_enable-cni/vsphere/enable-cni
+++ b/canonical-kubernetes/steps/04_enable-cni/vsphere/enable-cni
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -eu
+
+get_creds() {
+    endpoint="$(juju clouds --format=json | jq -r '.["'"$JUJU_CLOUD"'"].endpoint')"
+    region="$(juju clouds --format=json | jq -r '.["'"$JUJU_CLOUD"'"].regions | keys[0]')"
+    juju credentials "$JUJU_CLOUD" --show-secrets --format=json | jq 'if .["local-credentials"] then .["local-credentials"] else .["credentials"] end | .["'"$JUJU_CLOUD"'"]["cloud-credentials"]["'"$JUJU_CREDENTIAL"'"]["details"] | {"vsphere_ip": "'"$endpoint"'", "user", "password", "datacenter": "'"$region"'"}' | base64
+}
+
+enable_cni() {
+    if ! juju trust -m "$JUJU_CONTROLLER:$JUJU_MODEL" vsphere-integrator; then
+        >&2 echo "juju-trust not available; falling back to passing credentials via charm config."
+        >&2 echo "Note: Charm config can be read by anyone with read access to the model."
+        juju config -m "$JUJU_CONTROLLER:$JUJU_MODEL" vsphere-integrator credentials="$(get_creds)"
+    fi
+}

--- a/canonical-kubernetes/steps/04_enable-cni/vsphere/overlay.yaml
+++ b/canonical-kubernetes/steps/04_enable-cni/vsphere/overlay.yaml
@@ -1,0 +1,7 @@
+applications:
+  vsphere-integrator:
+    charm: cs:~containers/vsphere-integrator
+    num_units: 1
+relations:
+  - ['vsphere-integrator', 'kubernetes-master']
+  - ['vsphere-integrator', 'kubernetes-worker']


### PR DESCRIPTION
This adds vsphere-integrator when deploying a k8s spell on vsphere.  I tested k8s-core on a vsphere controller with:
```bash
$ uname -r
17.7.0
$ conjure-up --version
conjure-up 2.6.0
```

Worked smashingly well:

![screen shot 2018-09-07 at 4 20 34 pm](https://user-images.githubusercontent.com/4576822/45243573-faba3000-b2b9-11e8-8d11-3f37abb42401.png)
