### PR TITLE
update how we do DNS

### DIFF
--- a/openstack-novalxd/bundle.yaml
+++ b/openstack-novalxd/bundle.yaml
@@ -169,6 +169,7 @@ services:
       data-port: br-ex:eth1
       openstack-origin: cloud:xenial-queens
       worker-multiplier: 0.25
+      dns-servers: 10.101.0.1
   neutron-openvswitch:
     annotations:
       gui-x: '250'

--- a/openstack-novalxd/steps/00_process-providertype/before-deploy
+++ b/openstack-novalxd/steps/00_process-providertype/before-deploy
@@ -19,7 +19,9 @@ if [[ "$JUJU_PROVIDERTYPE" == "localhost" ]]; then
     lxc network create conjureup0 \
         ipv6.address=none \
         ipv6.nat=false \
+        ipv6.dhcp=false \
         ipv4.address=10.101.0.1/24 \
+        ipv4.dhcp=false \
         ipv4.nat=true || printf "conjureup0 network already exists" && true
 
     cat <<EOF> "$tmpfile"

--- a/openstack-novalxd/steps/03_neutron/after-deploy
+++ b/openstack-novalxd/steps/03_neutron/after-deploy
@@ -6,7 +6,7 @@ tmpfile=$(mktemp)
 
 cat "$CONJURE_UP_SPELLSDIR/sdk/common.sh" > "$tmpfile"
 
-cat "$(scriptPath)/../novarc" >> "$tmpfile"
+"$(scriptPath)/../novarc" >> "$tmpfile"
 
 cat "$(scriptPath)/neutron.sh" >> "$tmpfile"
 

--- a/openstack-novalxd/steps/03_neutron/neutron.sh
+++ b/openstack-novalxd/steps/03_neutron/neutron.sh
@@ -13,7 +13,7 @@ debug "Creating External Network"
 
 debug "Creating Internal Network"
 ./neutron-tenant-net -p admin -r provider-router \
-                     -N "$(get_host_ns)" internal 10.5.5.0/24 >> $NEUTRON_LOG 2>&1
+                     internal 10.5.5.0/24 >> $NEUTRON_LOG 2>&1
 
 debug "Setting security roles"
 


### PR DESCRIPTION
Also, this PR fixes a bug in the neutron.sh script that caused
environment variables to be printed rather than used in the
script.