### PR TITLE
revert graylog back to xenial

### DIFF
--- a/canonical-kubernetes/addons/graylog/bundle.yaml
+++ b/canonical-kubernetes/addons/graylog/bundle.yaml
@@ -15,7 +15,7 @@ services:
       logpath: '/var/log/*.log'
       kube_logs: True
   graylog:
-    charm: cs:bionic/graylog-19
+    charm: cs:xenial/graylog-19
     constraints: mem=4G
     num_units: 1
   mongodb:


### PR DESCRIPTION
Bionic snaps in lxc containers have issues:

https://forum.snapcraft.io/t/snaps-are-broken-in-bionic-lxd-container/7339/3

We can make the switch back to bionic once `core (edge) 16-2.36~pre1` goes stable.

Fixes #218 