### PR TITLE
use bionic for subs; bump revs to latest

### DIFF
--- a/canonical-kubernetes/addons/graylog/bundle.yaml
+++ b/canonical-kubernetes/addons/graylog/bundle.yaml
@@ -10,7 +10,7 @@ services:
     constraints: mem=4G root-disk=16G
     num_units: 1
   filebeat:
-    charm: cs:xenial/filebeat-19
+    charm: cs:bionic/filebeat-19
     options:
       logpath: '/var/log/*.log'
       kube_logs: True

--- a/canonical-kubernetes/addons/prometheus/bundle.yaml
+++ b/canonical-kubernetes/addons/prometheus/bundle.yaml
@@ -1,15 +1,15 @@
 services:
   grafana:
-    charm: cs:bionic/grafana-17
+    charm: cs:bionic/grafana-20
     constraints: mem=3G
     num_units: 1
     expose: true
   prometheus:
-    charm: cs:xenial/prometheus-7
+    charm: cs:bionic/prometheus2-8
     constraints: mem=3G root-disk=16G
     num_units: 1
   telegraf:
-    charm: cs:xenial/telegraf-16
+    charm: cs:bionic/telegraf-19
 relations:
   - ["prometheus:grafana-source", "grafana:grafana-source"]
   - ["telegraf:prometheus-client", "prometheus:target"]


### PR DESCRIPTION
Subordinates need to match the principal series, which has changed to bionic for k8s 1.12.  I've also bumped charm revisions and moved over to prometheus2 (which has bionic support).

I verified dashboards worked as expected on AWS.