### PR TITLE
Reduce default flavor disk size for openstack lxd

### DIFF
--- a/openstack-novalxd/steps/01_glance/glance.sh
+++ b/openstack-novalxd/steps/01_glance/glance.sh
@@ -31,6 +31,6 @@ if ! glance image-list --property-filter name="xenial$imagesuffix" | grep -q "xe
            --visibility=public --file="$HOME/glance-images/xenial-server-cloudimg-amd64-$imagetype" >> /dev/null 2>&1
 fi
 
-openstack flavor create --id 1 --ram 2048 --disk 20 --vcpus 1 m1.small >> $GLANCE_LOG 2>&1
+openstack flavor create --id 1 --ram 2048 --disk 8 --vcpus 1 m1.tiny >> $GLANCE_LOG 2>&1
 
 printf "Glance images for Bionic (18.04) and Xenial (16.04) are imported and accessible via Horizon dashboard."

--- a/openstack-novalxd/tests/verify
+++ b/openstack-novalxd/tests/verify
@@ -19,7 +19,7 @@ juju ssh -m $JUJU_CONTROLLER:$JUJU_MODEL \
 
 testLog "Verify creating a compute node"
 juju ssh -m $JUJU_CONTROLLER:$JUJU_MODEL \
-     nova-cloud-controller/0 "source novarc && nova boot --image xenial --flavor m1.small --key-name ubuntu-keypair --nic net-id=$(neutron net-list | grep internal | awk '{ print $2 }') xenial-test" >> $TEST_LOG 2>&1
+     nova-cloud-controller/0 "source novarc && nova boot --image xenial --flavor m1.tiny --key-name ubuntu-keypair --nic net-id=$(neutron net-list | grep internal | awk '{ print $2 }') xenial-test" >> $TEST_LOG 2>&1
 
 testLog "Verify access to the node"
 juju ssh -m $JUJU_CONTROLLER:$JUJU_MODEL \


### PR DESCRIPTION
Requiring a root disk of 20GB for every guest will cause users to
be unable to boot guests after only having launched a modest number
as the nova scheduler is looking for a compute node to have free
space that is larger than the flavor root disk size. Given
the default setup of flavors, images etc are really just examples
to get people going it seems reasonable to drop the required
root volume size to allow more guests to be created in a default
install. I have changed the flavor name to 'm1.tiny' to emphasis
that guests based on this flavor will only get very modest resources.