### PR TITLE
Switch default for "Create New Volume" for novalxd

### DIFF
--- a/openstack-novalxd/bundle.yaml
+++ b/openstack-novalxd/bundle.yaml
@@ -210,6 +210,7 @@ services:
     num_units: 1
     options:
       openstack-origin: cloud:xenial-queens
+      default-create-volume: False
   rabbitmq-server:
     annotations:
       gui-x: '500'


### PR DESCRIPTION
OpenStack with Nova-LXD does not support booting instances on the
resulting cloud from a cinder volume but that is the default
behaviour. This is called out in the guide but its easy to miss,
this change switches the default to not boot from volume.