### PR TITLE
Fix removing Flannel from CDK when Calico is selected

### DIFF
--- a/canonical-kubernetes/steps/01_select-network/flannel.yaml
+++ b/canonical-kubernetes/steps/01_select-network/flannel.yaml
@@ -1,9 +1,5 @@
 services:
-  flannel:
-    annotations:
-      gui-x: '450'
-      gui-y: '750'
-    charm: cs:~containers/flannel
+  flannel: all
 relations:
 - - flannel:etcd
   - etcd:db


### PR DESCRIPTION
The addition of resource pinning to the bundle caused the Flannel fragment to not be completely removed when Calico is selected, resulting in an invalid bundle. Note that "all" works because of this fallback: https://github.com/conjure-up/conjure-up/blob/master/conjureup/bundle.py#L258-L259

Fixes conjure-up/conjure-up#1549