### PR TITLE
refresh k8s monitoring stack

### DIFF
--- a/canonical-kubernetes/addons/graylog/bundle.yaml
+++ b/canonical-kubernetes/addons/graylog/bundle.yaml
@@ -6,20 +6,20 @@ services:
     options:
       enable_modules: "headers proxy_html proxy_http"
   elasticsearch:
-    charm: cs:bionic/elasticsearch-31
+    charm: cs:bionic/elasticsearch-32
     constraints: mem=4G root-disk=16G
     num_units: 1
   filebeat:
-    charm: cs:bionic/filebeat-19
+    charm: cs:bionic/filebeat-20
     options:
-      logpath: '/var/log/*.log'
+      logpath: '/var/log/*.log /root/cdk/audit/*.log'
       kube_logs: True
   graylog:
-    charm: cs:xenial/graylog-19
+    charm: cs:bionic/graylog-23
     constraints: mem=4G
     num_units: 1
   mongodb:
-    charm: cs:bionic/mongodb-49
+    charm: cs:bionic/mongodb-52
     num_units: 1
     options:
       extra_daemon_options: "--bind_ip_all"

--- a/canonical-kubernetes/addons/prometheus/bundle.yaml
+++ b/canonical-kubernetes/addons/prometheus/bundle.yaml
@@ -1,6 +1,6 @@
 services:
   grafana:
-    charm: cs:bionic/grafana-20
+    charm: cs:bionic/grafana-23
     constraints: mem=3G
     num_units: 1
     expose: true
@@ -9,7 +9,7 @@ services:
     constraints: mem=3G root-disk=16G
     num_units: 1
   telegraf:
-    charm: cs:bionic/telegraf-19
+    charm: cs:bionic/telegraf-27
 relations:
   - ["prometheus:grafana-source", "grafana:grafana-source"]
   - ["telegraf:prometheus-client", "prometheus:target"]


### PR DESCRIPTION
- bump up charm revisions to latest (grafana is currently broken without this)
- add k8s audit log to filebeat
- switch graylog over to bionic now that core-16 handles bionic snaps in lxc containers

Tested on aws; looks good.