### PR TITLE
bump lma revs for cdk spell

### DIFF
--- a/charmed-kubernetes/addons/graylog/bundle.yaml
+++ b/charmed-kubernetes/addons/graylog/bundle.yaml
@@ -6,17 +6,19 @@ services:
     options:
       enable_modules: "headers proxy_html proxy_http"
   elasticsearch:
-    charm: cs:bionic/elasticsearch-32
-    constraints: mem=4G root-disk=16G
+    charm: cs:bionic/elasticsearch-37
+    constraints: mem=7G root-disk=16G
     num_units: 1
-  filebeat:
-    charm: cs:bionic/filebeat-20
     options:
-      logpath: '/var/log/*.log /root/cdk/audit/*.log'
+      apt-repository: "deb https://artifacts.elastic.co/packages/6.x/apt stable main"
+  filebeat:
+    charm: cs:bionic/filebeat-23
+    options:
+      logpath: '/var/log/*.log /var/log/*/*.log /root/cdk/audit/*.log'
       kube_logs: True
   graylog:
-    charm: cs:bionic/graylog-23
-    constraints: mem=4G
+    charm: cs:~kwmonroe/graylog-3
+    constraints: mem=7G root-disk=16G
     num_units: 1
   mongodb:
     charm: cs:bionic/mongodb-52

--- a/charmed-kubernetes/addons/graylog/bundle.yaml
+++ b/charmed-kubernetes/addons/graylog/bundle.yaml
@@ -17,7 +17,7 @@ services:
       logpath: '/var/log/*.log /var/log/*/*.log /root/cdk/audit/*.log'
       kube_logs: True
   graylog:
-    charm: cs:~kwmonroe/graylog-3
+    charm: cs:~kwmonroe/graylog-4
     constraints: mem=7G root-disk=16G
     num_units: 1
   mongodb:

--- a/charmed-kubernetes/addons/graylog/steps/01_install-graylog/graylog-vhost.tmpl
+++ b/charmed-kubernetes/addons/graylog/steps/01_install-graylog/graylog-vhost.tmpl
@@ -1,10 +1,5 @@
 <Location "/">
-    RequestHeader set X-Graylog-Server-URL "http://{{servername}}/api/"
+    RequestHeader set X-Graylog-Server-URL "http://{{servername}}/"
     ProxyPass http://{{graylog_web}}/
     ProxyPassReverse http://{{graylog_web}}/
-</Location>
-
-<Location "/api/">
-    ProxyPass http://{{graylog_api}}/api/
-    ProxyPassReverse http://{{graylog_api}}/api/
 </Location>

--- a/charmed-kubernetes/addons/prometheus/bundle.yaml
+++ b/charmed-kubernetes/addons/prometheus/bundle.yaml
@@ -1,11 +1,11 @@
 services:
   grafana:
-    charm: cs:bionic/grafana-23
-    constraints: mem=3G
+    charm: cs:bionic/grafana-24
+    constraints: mem=3G root-disk=16G
     num_units: 1
     expose: true
   prometheus:
-    charm: cs:bionic/prometheus2-8
+    charm: cs:bionic/prometheus2-9
     constraints: mem=3G root-disk=16G
     num_units: 1
   telegraf:


### PR DESCRIPTION
Tested well on AWS:

- elastic stack is now v6
- revisit constraints and set sane defaults
- graylog is now v3 (this is in my personal namespace until we have an official graylog v3 snap)